### PR TITLE
Add tasks to build the add-on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .gradle
 /build
 /buildSrc/build
+/apigen/build
 
 # IDEA
 # ----
@@ -24,6 +25,7 @@
 *.settings
 /bin
 /buildSrc/bin
+/apigen/bin
 
 # NetBeans
 # --------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,66 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+First alpha release.
+
+### Added
+A plugin with ID `org.zaproxy.add-on` applied after `JavaPlugin` thus allowing to build ZAP
+add-ons written (at least) in Java, Groovy, or Kotlin.
+
+The plugin provides the following features:
+
+#### Extension
+ - `zapAddOn` to configure the ID, name, status, version, and target ZAP version of the add-on. It also
+ provides the following extensions:
+   - `manifest` to configure the generated add-on manifest (`ZapAddOn.xml` file).
+   - `zapVersions` to configure the generated `ZapVersions.xml` file (metadata for release to ZAP
+   marketplace).
+   - `apiClientGen` to configure the generated ZAP API client files.
+   - `wikiGen` to configure the generation of the wiki files.
+
+#### Conventions
+ - The add-on help, in JavaHelp format, will be read from `src/main/javahelp/`.
+ - Files to be deployed to ZAP home directory are read from `src/main/zapHomeFiles/`, automatically
+ added to main resources and declared in the add-on manifest.
+
+#### Configurations
+ - `zap` - the ZAP dependency, automatically added to `compileOnly` and `testImplementation`. Defaults
+ to `org.zaproxy:zap` with the ZAP version specified in the `zapAddOn` extension.
+ - `javahelp` - the dependencies to use with JavaHelp indexer. Defaults to `javax.help:javahelp:2.0.05`.
+
+#### Tasks
+Added by the plugin:
+ - `generateZapAddOnManifest` - to generate the manifest file for the add-on, added to `jar` task.
+ - `generateZapApiClientFiles` - to generate the ZAP API client files.
+ - `generateZapVersionsFile` - to generate the `ZapVersion.xml` file.
+ - `jarZapAddOn` - to assemble the add-on (dependency of `assemble` task), it includes the default `jar`,
+ the `runtimeClasspath`, and the help files. Placed in the directory `build/zapAddOn/bin/`.
+ - `jhindexer-*` - to build the JavaHelp indexes, one for each `HelpSet` in `src/main/javahelp/`.
+ - `generateWiki-*` - to generate the wiki files, one for each `HelpSet` in `src/main/javahelp/`.
+ - `copyWiki-*` - to copy the generated wiki files to a directory, one for each `HelpSet` in `src/main/javahelp/`.
+ - `copyZapAddOn` - to copy the add-on to zaproxy project.
+ - `deployZapAddOn` - to deploy the add-on and its home files to ZAP home dir.
+ - `installZapAddOn` - to install the add-on into ZAP.
+ - `uninstallZapAddOn` - to uninstall the add-on from ZAP.
+
+Provided by the plugin:
+ - `org.zaproxy.gradle.addon.apigen.tasks.GenerateApiClientFiles` - generates the ZAP API client files.
+ - `org.zaproxy.gradle.addon.jh.tasks.JavaHelpIndexer` - invokes `jhindexer` for a given collection
+ of files.
+ - `org.zaproxy.gradle.addon.manifest.tasks.ConvertChangelogToChanges` - converts a changelog (in
+ Keep a Changelog format) to manifest changes (HTML).
+ - `org.zaproxy.gradle.addon.manifest.tasks.GenerateManifestFile` - generates the add-on manifest.
+ - `org.zaproxy.gradle.addon.misc.CopyAddOn` - copies the add-on (and deletes old ones), defaults to zaproxy project.
+ - `org.zaproxy.gradle.addon.misc.DeployAddOn` - deploys the add-on and its home files to ZAP home dir.
+ - `org.zaproxy.gradle.addon.misc.InstallAddOn` - installs the add-on into ZAP.
+ - `org.zaproxy.gradle.addon.misc.UninstallAddOn` - uninstalls the add-on from ZAP.
+ - `org.zaproxy.gradle.addon.wiki.tasks.GenerateWiki` - generates the wiki files from help files in a JAR.
+ - `org.zaproxy.gradle.addon.zapversions.tasks.AggregateZapVersionsFiles` - merges `ZapVersions.xml`
+ from add-ons into a single file.
+ - `org.zaproxy.gradle.addon.zapversions.tasks.GenerateZapVersionsFile` - generates a `ZapVersions.xml`
+ file for a given add-on.
+ - `org.zaproxy.gradle.addon.zapversions.tasks.UpdateZapVersionsFile` - updates `ZapVersions.xml` files
+ with a `ZapVersions.xml` from an add-on.
 
 
 [Unreleased]: https://github.com/zaproxy/gradle-plugin-add-on/compare/47fb1005b5362df23bbe0aadf1935755db0dc811...HEAD

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# gradle-plugin-add-on
+
+A Gradle plugin to (help) build ZAP add-ons.
+
+The plugin requires at least Java 8 and Gradle 5.2.

--- a/apigen/apigen.gradle.kts
+++ b/apigen/apigen.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    `java-library`
+
+    id("com.diffplug.gradle.spotless")
+}
+
+repositories {
+    mavenCentral()
+}
+
+description = "The utility to help generate ZAP API client files for an add-on."
+
+dependencies {
+    compileOnly("org.zaproxy:zap:2.7.0")
+}
+
+tasks.jar.configure {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+
+    manifest {
+        attributes(mapOf("Class-Path" to "resources/"))
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.encoding = "UTF-8"
+    options.compilerArgs = listOf("-Xlint:all", "-Xlint:-path", "-Xlint:-options", "-Werror")
+}
+
+spotless {
+    java {
+        licenseHeaderFile("$rootDir/gradle/spotless/license.java")
+        googleJavaFormat().aosp()
+    }
+
+    kotlinGradle {
+        ktlint()
+    }
+}

--- a/apigen/src/main/java/org/zaproxy/zap/extension/api/ApiGenerator.java
+++ b/apigen/src/main/java/org/zaproxy/zap/extension/api/ApiGenerator.java
@@ -1,0 +1,156 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.ResourceBundle;
+import org.parosproxy.paros.common.AbstractParam;
+
+public class ApiGenerator {
+
+    private static final String CONF_FILE = "apigen.properties";
+
+    private static final String JAVA_OUTPUT_DIR =
+            "zap-api-java/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen";
+    private static final String PHP_OUTPUT_DIR = "zaproxy/php/api/zapv2/src/Zap";
+    private static final String PYTHON_OUTPUT_DIR = "zap-api-python/src/zapv2/";
+    private static final String NODE_OUTPUT_DIR = "zap-api-nodejs/src/";
+
+    private static Path baseDir;
+
+    @SuppressWarnings("unchecked")
+    public static void main(String[] args) throws Exception {
+        Path confFile = Paths.get(CONF_FILE);
+        if (Files.notExists(confFile)) {
+            System.err.println("Configuration file does not exist: " + confFile);
+            System.exit(1);
+        }
+
+        Properties conf = new Properties();
+        try (InputStream in = Files.newInputStream(confFile)) {
+            conf.load(in);
+        }
+
+        baseDir = getBaseDir(conf);
+
+        String classNameApi = conf.getProperty("api");
+        if (classNameApi == null || classNameApi.isEmpty()) {
+            throw new IllegalArgumentException("The property api is null or empty.");
+        }
+
+        Class<ApiImplementor> classApiImplementor =
+                (Class<ApiImplementor>) Class.forName(classNameApi);
+        ApiImplementor api = classApiImplementor.getDeclaredConstructor().newInstance();
+
+        String classNameOptions = conf.getProperty("options");
+        if (classNameOptions != null && !classNameOptions.isEmpty()) {
+            Class<AbstractParam> classAbstractParam =
+                    (Class<AbstractParam>) Class.forName(classNameOptions);
+            api.addApiOptions(classAbstractParam.getDeclaredConstructor().newInstance());
+        }
+
+        generate(api);
+    }
+
+    private static Path getBaseDir(Properties conf) {
+        String path = conf.getProperty("basedir");
+        if (path == null || path.isEmpty()) {
+            throw new IllegalArgumentException("The property basedir is null or empty.");
+        }
+
+        Path dir = Paths.get(path);
+        if (!Files.isDirectory(dir)) {
+            throw new IllegalArgumentException(
+                    "The property basedir is not a directory or does not exist: " + path);
+        }
+        return dir;
+    }
+
+    private static void generate(ApiImplementor api) {
+        List<ApiGeneratorWrapper> generators =
+                Arrays.asList(
+                        wrapper(JavaAPIGenerator.class, JAVA_OUTPUT_DIR),
+                        wrapper(NodeJSAPIGenerator.class, NODE_OUTPUT_DIR),
+                        wrapper(PhpAPIGenerator.class, PHP_OUTPUT_DIR),
+                        wrapper(PythonAPIGenerator.class, PYTHON_OUTPUT_DIR)
+                        // wrapper(WikiAPIGenerator.class, "zaproxy-wiki")
+                        );
+        ResourceBundle bundle =
+                ResourceBundle.getBundle(
+                        api.getClass().getPackage().getName() + ".resources.Messages",
+                        Locale.ENGLISH,
+                        api.getClass().getClassLoader(),
+                        ResourceBundle.Control.getControl(
+                                ResourceBundle.Control.FORMAT_PROPERTIES));
+
+        generators.forEach(generator -> generator.generate(api, bundle));
+    }
+
+    private static ApiGeneratorWrapper wrapper(
+            Class<? extends AbstractAPIGenerator> clazz, String outputDir) {
+        return new ApiGeneratorWrapper(clazz, baseDir.resolve(outputDir));
+    }
+
+    private static class ApiGeneratorWrapper {
+
+        private final Class<? extends AbstractAPIGenerator> clazz;
+        private final String outputDir;
+
+        public ApiGeneratorWrapper(Class<? extends AbstractAPIGenerator> clazz, Path outputDir) {
+            this.clazz = clazz;
+            this.outputDir = outputDir.toAbsolutePath().toString();
+        }
+
+        public void generate(ApiImplementor api, ResourceBundle bundle) {
+            AbstractAPIGenerator generator;
+            try {
+                generator = createInstance(bundle);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            try {
+                generator.generateAPIFiles(Arrays.asList(api));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        private AbstractAPIGenerator createInstance(ResourceBundle bundle) throws Exception {
+            try {
+                return clazz.getDeclaredConstructor(
+                                String.class, boolean.class, ResourceBundle.class)
+                        .newInstance(outputDir, true, bundle);
+            } catch (NoSuchMethodException e) {
+                return clazz.getDeclaredConstructor(String.class, boolean.class)
+                        .newInstance(outputDir, true);
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,23 +2,45 @@ plugins {
     `java-gradle-plugin`
     id("com.gradle.plugin-publish") version "0.10.0"
 
-    id("com.diffplug.gradle.spotless") version "3.16.0"
+    id("com.diffplug.gradle.spotless") version "3.18.0"
 }
 
 repositories {
-    mavenCentral()
     jcenter()
 }
 
 group = "org.zaproxy.gradle"
 version = "0.1.0-SNAPSHOT"
 
+dependencies {
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.8")
+    implementation("com.overzealous:remark:1.1.0")
+    val flexmarkVersion = "0.40.16"
+    implementation("com.vladsch.flexmark:flexmark-java:$flexmarkVersion")
+    implementation("com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:$flexmarkVersion")
+    implementation("com.vladsch.flexmark:flexmark-ext-gfm-tasklist:$flexmarkVersion")
+    implementation("com.vladsch.flexmark:flexmark-ext-tables:$flexmarkVersion")
+    implementation("commons-codec:commons-codec:1.11")
+    implementation("io.github.classgraph:classgraph:4.6.29")
+    implementation("org.apache.commons:commons-lang3:3.8.1")
+    implementation("org.zaproxy:zap-clientapi:1.6.0")
+}
+
+tasks.jar {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+
+    into("org/zaproxy/gradle/addon/apigen/") {
+        from(provider({ project(":apigen").tasks.named<Jar>("jar").flatMap { it.archiveFile } }))
+    }
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
     options.compilerArgs = listOf("-Xlint:all", "-Xlint:-path", "-Xlint:-options", "-Werror")
 }
@@ -48,16 +70,15 @@ pluginBundle {
             displayName = "Plugin to build ZAP add-ons"
         }
     }
-
-    mavenCoordinates {
-        groupId = "org.zaproxy.gradle"
-        artifactId = "gradle-plugin-addon"
-    }
 }
 
 spotless {
     java {
         licenseHeaderFile("gradle/spotless/license.java")
         googleJavaFormat().aosp()
+    }
+
+    kotlinGradle {
+        ktlint()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,18 @@
 rootProject.name = "gradle-plugin-add-on"
+
+include("apigen")
+
+rootProject.children.forEach { project -> setUpProject(settingsDir, project) }
+
+fun setUpProject(parentDir: File, project: ProjectDescriptor) {
+    project.projectDir = File(parentDir, project.name)
+    project.buildFileName = "${project.name}.gradle.kts"
+
+    if (!project.projectDir.isDirectory) {
+        throw AssertionError("Project ${project.name} has no directory: ${project.projectDir}")
+    }
+    if (!project.buildFile.isFile) {
+        throw AssertionError("Project ${project.name} has no build file: ${project.buildFile}")
+    }
+    project.children.forEach { project -> setUpProject(project.parent!!.projectDir, project) }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
@@ -19,11 +19,724 @@
  */
 package org.zaproxy.gradle.addon;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.zaproxy.gradle.addon.apigen.ApiClientGenExtension;
+import org.zaproxy.gradle.addon.apigen.tasks.GenerateApiClientFiles;
+import org.zaproxy.gradle.addon.internal.Constants;
+import org.zaproxy.gradle.addon.jh.tasks.JavaHelpIndexer;
+import org.zaproxy.gradle.addon.manifest.ManifestExtension;
+import org.zaproxy.gradle.addon.manifest.tasks.GenerateManifestFile;
+import org.zaproxy.gradle.addon.misc.CopyAddOn;
+import org.zaproxy.gradle.addon.misc.DeployAddOn;
+import org.zaproxy.gradle.addon.misc.InstallAddOn;
+import org.zaproxy.gradle.addon.misc.UninstallAddOn;
+import org.zaproxy.gradle.addon.wiki.WikiGenExtension;
+import org.zaproxy.gradle.addon.wiki.tasks.GenerateWiki;
+import org.zaproxy.gradle.addon.zapversions.ZapVersionsExtension;
+import org.zaproxy.gradle.addon.zapversions.tasks.GenerateZapVersionsFile;
 
+/** The plugin to help build ZAP add-ons. */
 public class AddOnPlugin implements Plugin<Project> {
 
+    /** The name of the extension to configure the ZAP add-on. */
+    public static final String MAIN_EXTENSION_NAME = "zapAddOn";
+
+    /**
+     * The name of the extension to configure the add-on manifest.
+     *
+     * <p>Accessible through the {@value #MAIN_EXTENSION_NAME} extension.
+     */
+    public static final String MANIFEST_EXTENSION_NAME = "manifest";
+
+    /**
+     * The name of the extension to configure the {@code ZapVersions.xml} file.
+     *
+     * <p>Accessible through the {@value #MAIN_EXTENSION_NAME} extension.
+     */
+    public static final String ZAP_VERSIONS_EXTENSION_NAME = "zapVersions";
+
+    /**
+     * The name of the extension to configure the generation of wiki files.
+     *
+     * <p>Accessible through the {@value #MAIN_EXTENSION_NAME} extension.
+     */
+    public static final String WIKI_GEN_EXTENSION_NAME = "wikiGen";
+
+    /**
+     * The name of the extension to configure the generation of API client files.
+     *
+     * <p>Accessible through the {@value #MAIN_EXTENSION_NAME} extension.
+     */
+    public static final String API_CLIENT_GEN_EXTENSION_NAME = "apiClientGen";
+
+    /** The name of the ZAP configuration. */
+    public static final String ZAP_CONFIGURATION_NAME = "zap";
+
+    /** The name of the JavaHelp configuration. */
+    public static final String JAVA_HELP_CONFIGURATION_NAME = "javahelp";
+
+    /** The name of the task that assembles the add-on. */
+    public static final String JAR_ZAP_ADD_ON_TASK_NAME = "jarZapAddOn";
+
+    static final String JAR_ZAP_ADD_ON_TASK_DESC = "Assembles the ZAP add-on.";
+
+    /**
+     * The name of the task that copies the add-on to zaproxy project.
+     *
+     * @see org.zaproxy.gradle.addon.misc.CopyAddOn
+     */
+    public static final String COPY_ADD_ON_TASK_NAME = "copyZapAddOn";
+
+    static final String COPY_ADD_ON_TASK_DESC =
+            "Copies the add-on to zaproxy project (defaults to \"$rootDir/../zaproxy/src/plugin/\").";
+
+    /**
+     * The name of the task that deploys the add-on and its home files to ZAP home dir.
+     *
+     * @see org.zaproxy.gradle.addon.misc.DeployAddOn
+     */
+    public static final String DEPLOY_ADD_ON_TASK_NAME = "deployZapAddOn";
+
+    static final String DEPLOY_ADD_ON_TASK_DESC =
+            "Deploys the add-on and its home files to ZAP home dir.\n"
+                    + "Defaults to dev home dir if not specified through the command line nor\n"
+                    + "through the system property \"zap.home.dir\". The command line argument\n"
+                    + "takes precedence over the system property.\n"
+                    + "By default the existing home files are deleted before deploying the new\n"
+                    + "files, to prevent stale files. This behaviour can be changed through the\n"
+                    + "command line.";
+
+    /**
+     * The name of the task that uninstalls the add-on from ZAP, using the ZAP API.
+     *
+     * @see org.zaproxy.gradle.addon.misc.UninstallAddOn
+     */
+    public static final String UNINSTALL_ADD_ON_TASK_NAME = "uninstallZapAddOn";
+
+    static final String UNINSTALL_ADD_ON_TASK_DESC =
+            "Uninstalls the add-on from ZAP, listening on 8080 by default.";
+
+    /**
+     * The name of the task that installs the add-on into ZAP, using the ZAP API.
+     *
+     * @see org.zaproxy.gradle.addon.misc.InstallAddOn
+     */
+    public static final String INSTALL_ADD_ON_TASK_NAME = "installZapAddOn";
+
+    static final String INSTALL_ADD_ON_TASK_DESC =
+            "Installs the add-on into ZAP, listening on 8080 by default.";
+
+    /**
+     * The name of the task that generates the add-on manifest ({@code ZapAddOn.xml}).
+     *
+     * @see org.zaproxy.gradle.addon.manifest.tasks.GenerateManifestFile
+     */
+    public static final String GENERATE_MANIFEST_TASK_NAME = "generateZapAddOnManifest";
+
+    static final String GENERATE_MANIFEST_TASK_DESC =
+            "Generates the manifest (ZapAddOn.xml) for the ZAP add-on.";
+
+    /**
+     * The name of the task that generates the versions file ({@code ZapVersions.xml}) for the
+     * add-on.
+     *
+     * @see org.zaproxy.gradle.addon.zapversions.tasks.GenerateZapVersionsFile
+     */
+    public static final String GENERATE_ZAP_VERSIONS_TASK_NAME = "generateZapVersionsFile";
+
+    static final String GENERATE_ZAP_VERSIONS_TASK_DESC =
+            "Generates the ZapVersions.xml file for the ZAP add-on.";
+
+    /**
+     * The name of the task that generates the API client files for the ZAP add-on.
+     *
+     * @see org.zaproxy.gradle.addon.apigen.tasks.GenerateApiClientFiles
+     */
+    public static final String GENERATE_API_CLIENT_TASK_NAME = "generateZapApiClientFiles";
+
+    static final String GENERATE_API_CLIENT_TASK_DESC =
+            "Generates the API client files for the ZAP add-on.";
+
+    private static final String ZAP_TASK_GROUP_NAME = "ZAP Add-On Misc";
+
+    private static final String ZAP_GROUP_ARTIFACT = "org.zaproxy:zap:";
+
+    private static final String JAVA_HELP_DEFAULT_DEPENDENCY = "javax.help:javahelp:2.0.05";
+
+    private static final String MAIN_OUTPUT_DIR = "zapAddOn";
+
     @Override
-    public void apply(Project project) {}
+    public void apply(Project project) {
+        project.getPlugins()
+                .withType(
+                        JavaPlugin.class,
+                        jp -> {
+                            AddOnPluginExtension extension =
+                                    project.getExtensions()
+                                            .create(
+                                                    MAIN_EXTENSION_NAME,
+                                                    AddOnPluginExtension.class,
+                                                    project);
+
+                            ConfigurationContainer confs = project.getConfigurations();
+
+                            NamedDomainObjectProvider<Configuration> zapConfig =
+                                    confs.register(
+                                            ZAP_CONFIGURATION_NAME,
+                                            config -> {
+                                                config.setVisible(false)
+                                                        .setDescription(
+                                                                "The ZAP artifact, automatically added to compileOnly and testImplementation.");
+
+                                                config.defaultDependencies(
+                                                        deps -> {
+                                                            boolean depNotAdded = true;
+                                                            Property<String> zapVersion =
+                                                                    extension.getZapVersion();
+                                                            if (zapVersion.isPresent()) {
+                                                                String version = zapVersion.get();
+                                                                if (!version.isEmpty()) {
+                                                                    deps.add(
+                                                                            project.getDependencies()
+                                                                                    .create(
+                                                                                            ZAP_GROUP_ARTIFACT
+                                                                                                    + version));
+                                                                    depNotAdded = false;
+                                                                }
+                                                            }
+
+                                                            if (depNotAdded) {
+                                                                project.getLogger()
+                                                                        .warn(
+                                                                                "Not adding ZAP dependency to {}, no ZAP version defined for the add-on.",
+                                                                                project);
+                                                            }
+                                                        });
+                                            });
+
+                            confs.named(
+                                    JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME,
+                                    e -> e.extendsFrom(zapConfig.get()));
+                            confs.named(
+                                    JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME,
+                                    e -> e.extendsFrom(zapConfig.get()));
+
+                            DirectoryProperty zapAddOnBuildDir =
+                                    project.getObjects()
+                                            .directoryProperty()
+                                            .convention(
+                                                    project.getLayout()
+                                                            .getBuildDirectory()
+                                                            .dir(MAIN_OUTPUT_DIR));
+
+                            setUpManifest(project, extension, zapAddOnBuildDir);
+                            setUpAddOnFiles(project, extension);
+                            setUpAddOn(project, extension, zapAddOnBuildDir);
+                            setUpJavaHelp(project, extension, zapAddOnBuildDir);
+                            setUpZapVersions(project, extension, zapAddOnBuildDir);
+                            setUpMiscTasks(project, extension);
+                            setUpApiClientGen(project, extension);
+                        });
+    }
+
+    private static void setUpManifest(
+            Project project, AddOnPluginExtension extension, DirectoryProperty zapAddOnBuildDir) {
+        ManifestExtension manifestExtension =
+                ((ExtensionAware) extension)
+                        .getExtensions()
+                        .create(MANIFEST_EXTENSION_NAME, ManifestExtension.class, project);
+        manifestExtension.getNotBeforeVersion().set(extension.getZapVersion());
+        manifestExtension
+                .getClasspath()
+                .from(
+                        project.getConvention()
+                                .getPlugin(JavaPluginConvention.class)
+                                .getSourceSets()
+                                .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                                .getOutput()
+                                .getClassesDirs());
+        manifestExtension.getOutputDir().set(zapAddOnBuildDir);
+
+        TaskProvider<GenerateManifestFile> generateTaskProvider =
+                project.getTasks()
+                        .register(
+                                GENERATE_MANIFEST_TASK_NAME,
+                                GenerateManifestFile.class,
+                                t -> {
+                                    t.setDescription(GENERATE_MANIFEST_TASK_DESC);
+                                    t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+
+                                    t.getAddOnName().set(extension.getAddOnName());
+                                    t.getVersion().set(extension.getAddOnVersion());
+                                    t.getSemVer().set(manifestExtension.getSemVer());
+                                    t.getStatus().set(extension.getAddOnStatus());
+                                    t.getAddOnDescription().set(manifestExtension.getDescription());
+                                    t.getAuthor().set(manifestExtension.getAuthor());
+                                    t.getUrl().set(manifestExtension.getUrl());
+                                    t.getChanges().set(manifestExtension.getChanges());
+                                    t.getChangesFile().set(manifestExtension.getChangesFile());
+                                    t.getDependencies().set(manifestExtension.getDependencies());
+                                    t.getBundle().set(manifestExtension.getBundle());
+                                    t.getHelpSet().set(manifestExtension.getHelpSet());
+                                    t.getClassnames().set(manifestExtension.getClassnames());
+
+                                    t.setExtensions(manifestExtension.getAddOnExtensions());
+                                    t.setAscanrules(manifestExtension.getAscanrules());
+                                    t.setPscanrules(manifestExtension.getPscanrules());
+
+                                    t.getFiles().from(manifestExtension.getFiles());
+                                    t.getNotBeforeVersion()
+                                            .set(manifestExtension.getNotBeforeVersion());
+                                    t.getNotFromVersion()
+                                            .set(manifestExtension.getNotFromVersion());
+                                    t.getClasspath().from(manifestExtension.getClasspath());
+
+                                    t.getClasspath().setFrom(manifestExtension.getClasspath());
+
+                                    t.getOutputDir().set(manifestExtension.getOutputDir());
+                                });
+        project.getTasks()
+                .named(JavaPlugin.JAR_TASK_NAME, Jar.class, jar -> jar.from(generateTaskProvider));
+    }
+
+    private static void setUpAddOnFiles(Project project, AddOnPluginExtension extension) {
+        DirectoryProperty srcDir = project.getObjects().directoryProperty();
+        srcDir.set(project.file("src/main/zapHomeFiles"));
+
+        ((ExtensionAware) extension)
+                .getExtensions()
+                .getByType(ManifestExtension.class)
+                .getFiles()
+                .from(srcDir);
+
+        JavaPluginConvention javaConvention =
+                project.getConvention().getPlugin(JavaPluginConvention.class);
+        javaConvention
+                .getSourceSets()
+                .named(
+                        SourceSet.MAIN_SOURCE_SET_NAME,
+                        sourceSet -> sourceSet.getResources().srcDir(srcDir));
+    }
+
+    private static void setUpAddOn(
+            Project project, AddOnPluginExtension extension, DirectoryProperty zapAddOnBuildDir) {
+        TaskProvider<Jar> jarAddOn =
+                project.getTasks()
+                        .register(
+                                JAR_ZAP_ADD_ON_TASK_NAME,
+                                Jar.class,
+                                t -> {
+                                    t.setDescription(JAR_ZAP_ADD_ON_TASK_DESC);
+                                    t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+
+                                    t.getArchiveBaseName().set(extension.getAddOnId());
+                                    t.getArchiveAppendix()
+                                            .set(
+                                                    extension
+                                                            .getAddOnStatus()
+                                                            .map(AddOnStatus::toString));
+                                    t.getArchiveVersion().set(extension.getAddOnVersion());
+                                    t.getArchiveExtension().set(Constants.ADD_ON_FILE_EXTENSION);
+                                    t.getDestinationDirectory().set(zapAddOnBuildDir.dir("bin"));
+
+                                    t.getOutputs()
+                                            .upToDateWhen(
+                                                    task -> {
+                                                        Path dir =
+                                                                t.getDestinationDirectory()
+                                                                        .getAsFile()
+                                                                        .get()
+                                                                        .toPath();
+                                                        if (!Files.exists(dir)) {
+                                                            return true;
+                                                        }
+                                                        try (Stream<Path> stream =
+                                                                Files.find(
+                                                                        dir,
+                                                                        1,
+                                                                        (p, a) ->
+                                                                                p.getFileName()
+                                                                                        .toString()
+                                                                                        .endsWith(
+                                                                                                Constants
+                                                                                                        .ADD_ON_FILE_EXTENSION))) {
+                                                            return stream.count() == 1;
+                                                        } catch (IOException e) {
+                                                            throw new UncheckedIOException(e);
+                                                        }
+                                                    });
+                                    // Do not use a lambda, not supported by up-to-date checks.
+                                    t.doFirst(
+                                            new Action<Task>() {
+
+                                                @Override
+                                                public void execute(Task task) {
+                                                    project.delete(
+                                                            project.fileTree(
+                                                                            t
+                                                                                    .getDestinationDirectory())
+                                                                    .getFiles());
+                                                }
+                                            });
+
+                                    t.setPreserveFileTimestamps(false);
+                                    t.setReproducibleFileOrder(true);
+
+                                    Jar jar =
+                                            project.getTasks()
+                                                    .named(JavaPlugin.JAR_TASK_NAME, Jar.class)
+                                                    .get();
+                                    t.with(jar);
+                                    t.getManifest().from(jar.getManifest());
+
+                                    NamedDomainObjectProvider<Configuration> runtimeClasspath =
+                                            project.getConfigurations()
+                                                    .named(
+                                                            JavaPlugin
+                                                                    .RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+                                    t.dependsOn(runtimeClasspath);
+                                    t.from(
+                                                    project.provider(
+                                                            () ->
+                                                                    runtimeClasspath.get()
+                                                                            .getFiles().stream()
+                                                                            .map(
+                                                                                    e ->
+                                                                                            e
+                                                                                                            .isDirectory()
+                                                                                                    ? e
+                                                                                                    : project
+                                                                                                            .zipTree(
+                                                                                                                    e))
+                                                                            .collect(
+                                                                                    Collectors
+                                                                                            .toList())))
+                                            .exclude(
+                                                    "META-INF/*.SF",
+                                                    "META-INF/*.DSA",
+                                                    "META-INF/*.RSA");
+                                });
+        project.getTasks()
+                .named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME, t -> t.dependsOn(jarAddOn));
+    }
+
+    private static void setUpJavaHelp(
+            Project project, AddOnPluginExtension extension, DirectoryProperty zapAddOnBuildDir) {
+        NamedDomainObjectProvider<Configuration> javaHelpConfig =
+                project.getConfigurations()
+                        .register(
+                                JAVA_HELP_CONFIGURATION_NAME,
+                                conf ->
+                                        conf.setVisible(false)
+                                                .setDescription(
+                                                        "The dependencies for JavaHelp related tasks.")
+                                                .defaultDependencies(
+                                                        deps ->
+                                                                deps.add(
+                                                                        project.getDependencies()
+                                                                                .create(
+                                                                                        JAVA_HELP_DEFAULT_DEPENDENCY))));
+
+        project.getTasks()
+                .withType(JavaHelpIndexer.class)
+                .configureEach(jhi -> jhi.getClasspath().from(javaHelpConfig));
+
+        DirectoryProperty srcDir = project.getObjects().directoryProperty();
+        File srcDirFile = project.file("src/main/javahelp");
+        srcDir.set(srcDirFile);
+
+        TaskProvider<Jar> addOnTask =
+                project.getTasks().named(JAR_ZAP_ADD_ON_TASK_NAME, Jar.class, t -> t.from(srcDir));
+
+        Directory mainJhiDestDir = zapAddOnBuildDir.dir("jhindexes").get();
+
+        Set<File> helpsets =
+                project.fileTree(srcDir)
+                        .filter(e -> e.getName().endsWith(Constants.HELPSET_FILE_EXTENSION))
+                        .getFiles();
+        helpsets.forEach(
+                helpset -> {
+                    String name = helpset.getParentFile().getName();
+                    Directory dir = mainJhiDestDir.dir(name);
+
+                    TaskProvider<JavaHelpIndexer> jhi =
+                            project.getTasks()
+                                    .register(
+                                            "jhindexer-" + name,
+                                            JavaHelpIndexer.class,
+                                            t -> {
+                                                t.setDescription(
+                                                        "Generates the JavaHelp indexes for "
+                                                                + name
+                                                                + " dir.");
+                                                t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+
+                                                t.getHelpset().set(helpset);
+                                                t.getOutputPrefix()
+                                                        .set(
+                                                                srcDir.getAsFile()
+                                                                        .get()
+                                                                        .toPath()
+                                                                        .relativize(
+                                                                                helpset.toPath()
+                                                                                        .getParent())
+                                                                        .toString());
+                                                t.setSource(helpset.getParentFile());
+                                                t.getDestinationDir().set(dir);
+                                            });
+                    addOnTask.configure(t -> t.from(jhi));
+                });
+
+        Directory mainWikiDestDir = zapAddOnBuildDir.dir("wiki").get();
+
+        TaskProvider<Jar> jarWikiHelpTask =
+                project.getTasks()
+                        .register(
+                                "jarJavaHelpDataForWiki",
+                                Jar.class,
+                                t -> {
+                                    t.setDescription(
+                                            "Assembles the JAR used for the wiki generation from the JavaHelp data.");
+                                    t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+
+                                    t.from(
+                                            srcDir,
+                                            project.getConvention()
+                                                    .getPlugin(JavaPluginConvention.class)
+                                                    .getSourceSets()
+                                                    .named(SourceSet.MAIN_SOURCE_SET_NAME)
+                                                    .map(SourceSet::getResources));
+                                    t.getArchiveBaseName().set("javaHelpData");
+                                    t.getDestinationDirectory().set(mainWikiDestDir);
+                                    t.getArchiveVersion().set("");
+                                    t.setPreserveFileTimestamps(false);
+                                    t.setReproducibleFileOrder(true);
+                                });
+
+        WikiGenExtension wikiGenExtension =
+                ((ExtensionAware) extension)
+                        .getExtensions()
+                        .create(WIKI_GEN_EXTENSION_NAME, WikiGenExtension.class, project);
+
+        helpsets.forEach(
+                helpset -> {
+                    File helpDir = helpset.getParentFile();
+                    String name = helpDir.getName();
+
+                    Directory wikiDir = mainWikiDestDir.dir(name);
+                    TaskProvider<GenerateWiki> wikiTask =
+                            project.getTasks()
+                                    .register(
+                                            "generateWiki-" + name,
+                                            GenerateWiki.class,
+                                            t -> {
+                                                t.setDescription(
+                                                        "Generates the wiki files from "
+                                                                + name
+                                                                + " dir.");
+                                                t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+
+                                                t.getJavaHelpData()
+                                                        .set(
+                                                                jarWikiHelpTask.flatMap(
+                                                                        Jar::getArchiveFile));
+
+                                                t.getContentsDir()
+                                                        .set(
+                                                                srcDirFile
+                                                                        .toPath()
+                                                                        .relativize(
+                                                                                helpDir.toPath()
+                                                                                        .resolve(
+                                                                                                "contents"))
+                                                                        .toString());
+
+                                                t.getToc()
+                                                        .set(
+                                                                srcDirFile
+                                                                        .toPath()
+                                                                        .relativize(
+                                                                                helpDir.toPath()
+                                                                                        .resolve(
+                                                                                                "toc.xml"))
+                                                                        .toString());
+                                                t.getMap()
+                                                        .set(
+                                                                srcDirFile
+                                                                        .toPath()
+                                                                        .relativize(
+                                                                                helpDir.toPath()
+                                                                                        .resolve(
+                                                                                                "map.jhm"))
+                                                                        .toString());
+                                                t.getWikiFilesPrefix()
+                                                        .set(wikiGenExtension.getWikiFilesPrefix());
+
+                                                t.getWikiToc().set(wikiDir.file("_Sidebar.md"));
+                                                t.getOutputDir().set(wikiDir.dir("contents"));
+                                            });
+
+                    project.getTasks()
+                            .register(
+                                    "copyWiki-" + name,
+                                    Copy.class,
+                                    t -> {
+                                        t.setDescription(
+                                                "Copies the wiki files of "
+                                                        + name
+                                                        + " dir to the wiki dir.");
+                                        t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+                                        t.from(wikiTask.map(GenerateWiki::getOutputDir));
+                                        t.into(wikiGenExtension.getWikiDir());
+                                    });
+                });
+    }
+
+    private static void setUpZapVersions(
+            Project project, AddOnPluginExtension extension, DirectoryProperty zapAddOnBuildDir) {
+        ZapVersionsExtension zapVersionsExtension =
+                ((ExtensionAware) extension)
+                        .getExtensions()
+                        .create(ZAP_VERSIONS_EXTENSION_NAME, ZapVersionsExtension.class, project);
+        zapVersionsExtension
+                .getFile()
+                .set(zapAddOnBuildDir.file(GenerateZapVersionsFile.ZAP_VERSIONS_XML));
+
+        project.getTasks()
+                .register(
+                        GENERATE_ZAP_VERSIONS_TASK_NAME,
+                        GenerateZapVersionsFile.class,
+                        t -> {
+                            t.setDescription(GENERATE_ZAP_VERSIONS_TASK_DESC);
+                            t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+
+                            t.getAddOnId().set(extension.getAddOnId());
+                            t.getAddOn()
+                                    .set(
+                                            project.getTasks()
+                                                    .named(JAR_ZAP_ADD_ON_TASK_NAME, Jar.class)
+                                                    .flatMap(Jar::getArchiveFile));
+                            t.getDownloadUrl().set(zapVersionsExtension.getDownloadUrl());
+                            t.getChecksumAlgorithm()
+                                    .set(zapVersionsExtension.getChecksumAlgorithm());
+                            t.getFile().set(zapVersionsExtension.getFile());
+                        });
+    }
+
+    private static void setUpMiscTasks(Project project, AddOnPluginExtension extension) {
+        project.getTasks()
+                .withType(CopyAddOn.class, t -> t.getAddOnId().set(extension.getAddOnId()));
+
+        TaskProvider<Jar> jarZapAddOn =
+                project.getTasks().named(JAR_ZAP_ADD_ON_TASK_NAME, Jar.class);
+        Provider<RegularFile> jarFile = jarZapAddOn.flatMap(Jar::getArchiveFile);
+
+        project.getTasks()
+                .register(
+                        COPY_ADD_ON_TASK_NAME,
+                        CopyAddOn.class,
+                        t -> {
+                            t.setDescription(COPY_ADD_ON_TASK_DESC);
+                            t.setGroup(ZAP_TASK_GROUP_NAME);
+                        });
+
+        project.getTasks()
+                .register(
+                        DEPLOY_ADD_ON_TASK_NAME,
+                        DeployAddOn.class,
+                        t -> {
+                            t.setDescription(DEPLOY_ADD_ON_TASK_DESC);
+                            t.setGroup(ZAP_TASK_GROUP_NAME);
+
+                            t.getAddOn().set(jarFile);
+                            t.getFiles()
+                                    .from(
+                                            ((ExtensionAware) extension)
+                                                    .getExtensions()
+                                                    .getByType(ManifestExtension.class)
+                                                    .getFiles());
+                        });
+
+        TaskProvider<UninstallAddOn> uninstallAddOn =
+                project.getTasks()
+                        .register(
+                                UNINSTALL_ADD_ON_TASK_NAME,
+                                UninstallAddOn.class,
+                                t -> {
+                                    t.setDescription(UNINSTALL_ADD_ON_TASK_DESC);
+                                    t.setGroup(ZAP_TASK_GROUP_NAME);
+                                    t.getAddOnId().set(extension.getAddOnId());
+                                });
+        jarZapAddOn.configure(t -> t.mustRunAfter(uninstallAddOn));
+
+        project.getTasks()
+                .register(
+                        INSTALL_ADD_ON_TASK_NAME,
+                        InstallAddOn.class,
+                        t -> {
+                            t.setDescription(INSTALL_ADD_ON_TASK_DESC);
+                            t.setGroup(ZAP_TASK_GROUP_NAME);
+
+                            t.dependsOn(uninstallAddOn);
+                            t.getAddOn().set(jarFile);
+                        });
+    }
+
+    private static void setUpApiClientGen(Project project, AddOnPluginExtension extension) {
+        ApiClientGenExtension apiClientGenExtension =
+                ((ExtensionAware) extension)
+                        .getExtensions()
+                        .create(
+                                API_CLIENT_GEN_EXTENSION_NAME,
+                                ApiClientGenExtension.class,
+                                project);
+        apiClientGenExtension
+                .getClasspath()
+                .from(
+                        project.getConfigurations()
+                                .named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME))
+                .from(project.getTasks().named(JavaPlugin.JAR_TASK_NAME));
+
+        project.getTasks()
+                .register(
+                        GENERATE_API_CLIENT_TASK_NAME,
+                        GenerateApiClientFiles.class,
+                        t -> {
+                            t.setDescription(GENERATE_API_CLIENT_TASK_DESC);
+                            t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+
+                            t.getApi().set(apiClientGenExtension.getApi());
+                            t.getOptions().set(apiClientGenExtension.getOptions());
+                            t.getMessages().set(apiClientGenExtension.getMessages());
+                            t.getBaseDir().set(apiClientGenExtension.getBaseDir());
+                            t.getClasspath().setFrom(apiClientGenExtension.getClasspath());
+                        });
+    }
 }

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPluginException.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPluginException.java
@@ -1,0 +1,33 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon;
+
+public class AddOnPluginException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public AddOnPluginException(String message) {
+        super(message);
+    }
+
+    public AddOnPluginException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPluginExtension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPluginExtension.java
@@ -1,0 +1,68 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon;
+
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+
+/** The entry extension of the plugin. */
+public class AddOnPluginExtension {
+
+    private static final String DEFAULT_ZAP_VERSION = "2.7.0";
+
+    private final Property<String> addOnId;
+    private final Property<String> addOnName;
+    private final Property<AddOnStatus> addOnStatus;
+    private final Property<String> addOnVersion;
+    private final Property<String> zapVersion;
+
+    @Inject
+    public AddOnPluginExtension(Project project) {
+        this.addOnId = project.getObjects().property(String.class);
+        this.addOnId.set(project.getName());
+        this.addOnName = project.getObjects().property(String.class);
+        this.addOnStatus =
+                project.getObjects().property(AddOnStatus.class).value(AddOnStatus.ALPHA);
+        this.addOnVersion = project.getObjects().property(String.class);
+        this.addOnVersion.set(project.provider(() -> project.getVersion().toString()));
+        this.zapVersion = project.getObjects().property(String.class).value(DEFAULT_ZAP_VERSION);
+    }
+
+    public Property<String> getAddOnId() {
+        return addOnId;
+    }
+
+    public Property<String> getAddOnName() {
+        return addOnName;
+    }
+
+    public Property<AddOnStatus> getAddOnStatus() {
+        return addOnStatus;
+    }
+
+    public Property<String> getAddOnVersion() {
+        return addOnVersion;
+    }
+
+    public Property<String> getZapVersion() {
+        return zapVersion;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnStatus.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnStatus.java
@@ -1,0 +1,34 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon;
+
+import java.util.Locale;
+
+/** The status that an add-on can have. */
+public enum AddOnStatus {
+    ALPHA,
+    BETA,
+    RELEASE;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/apigen/ApiClientGenExtension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/apigen/ApiClientGenExtension.java
@@ -1,0 +1,68 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.apigen;
+
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+
+public class ApiClientGenExtension {
+
+    private final Property<String> api;
+    private final Property<String> options;
+    private final RegularFileProperty messages;
+    private final DirectoryProperty baseDir;
+    private final ConfigurableFileCollection classpath;
+
+    @Inject
+    public ApiClientGenExtension(Project project) {
+        ObjectFactory objects = project.getObjects();
+        api = objects.property(String.class);
+        options = objects.property(String.class);
+        messages = objects.fileProperty();
+        baseDir = objects.directoryProperty();
+        baseDir.set(project.getRootDir().getParentFile());
+        classpath = project.files();
+    }
+
+    public Property<String> getApi() {
+        return api;
+    }
+
+    public Property<String> getOptions() {
+        return options;
+    }
+
+    public RegularFileProperty getMessages() {
+        return messages;
+    }
+
+    public DirectoryProperty getBaseDir() {
+        return baseDir;
+    }
+
+    public ConfigurableFileCollection getClasspath() {
+        return classpath;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/apigen/tasks/GenerateApiClientFiles.java
+++ b/src/main/java/org/zaproxy/gradle/addon/apigen/tasks/GenerateApiClientFiles.java
@@ -1,0 +1,132 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.apigen.tasks;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Properties;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+/** A task to generate the API client files of an add-on. */
+public class GenerateApiClientFiles extends DefaultTask {
+
+    private final Property<String> api;
+    private final Property<String> options;
+    private final RegularFileProperty messages;
+    private final DirectoryProperty baseDir;
+    private final ConfigurableFileCollection classpath;
+
+    public GenerateApiClientFiles() {
+        ObjectFactory objects = getProject().getObjects();
+        api = objects.property(String.class);
+        options = objects.property(String.class);
+        messages = objects.fileProperty();
+        baseDir = objects.directoryProperty();
+        baseDir.set(getProject().getRootDir().getParentFile());
+        classpath = getProject().files();
+    }
+
+    @Input
+    public Property<String> getApi() {
+        return api;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getOptions() {
+        return options;
+    }
+
+    @InputFile
+    @Optional
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getMessages() {
+        return messages;
+    }
+
+    @Input
+    @Optional
+    public DirectoryProperty getBaseDir() {
+        return baseDir;
+    }
+
+    @Classpath
+    public ConfigurableFileCollection getClasspath() {
+        return classpath;
+    }
+
+    @TaskAction
+    public void generate() throws IOException {
+        Path wd = getTemporaryDir().toPath();
+
+        // For compatibility with ZAP <= 2.7.0.
+        Path messagesProperties = wd.resolve("resources/lang/Messages.properties");
+        Files.createDirectories(messagesProperties.getParent());
+        if (messages.isPresent()) {
+            Files.copy(
+                    messages.get().getAsFile().toPath(),
+                    messagesProperties,
+                    StandardCopyOption.REPLACE_EXISTING);
+        } else {
+            Files.deleteIfExists(messagesProperties);
+            Files.createFile(messagesProperties);
+        }
+
+        Path apiGenJar = wd.resolve("apigen.jar");
+        try (InputStream in =
+                GenerateApiClientFiles.class
+                        .getClassLoader()
+                        .getResourceAsStream("org/zaproxy/gradle/addon/apigen/apigen.jar")) {
+            Files.copy(in, apiGenJar, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        try (OutputStream out = Files.newOutputStream(wd.resolve("apigen.properties"))) {
+            Properties conf = new Properties();
+            conf.setProperty("api", api.get());
+            conf.setProperty("options", options.isPresent() ? options.get() : "");
+            conf.setProperty("basedir", baseDir.get().getAsFile().getAbsolutePath());
+            conf.store(out, null);
+        }
+
+        getProject()
+                .javaexec(
+                        spec -> {
+                            spec.setClasspath(getProject().files(classpath, apiGenJar.toFile()));
+                            spec.setWorkingDir(wd.toFile());
+                            spec.setMain("org.zaproxy.zap.extension.api.ApiGenerator");
+                        });
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/Constants.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/Constants.java
@@ -1,0 +1,32 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal;
+
+/** Constant values used throughout the plugin. */
+public final class Constants {
+
+    public static final String ADD_ON_MANIFEST_FILE_NAME = "ZapAddOn.xml";
+
+    public static final String ADD_ON_FILE_EXTENSION = "zap";
+
+    public static final String HELPSET_FILE_EXTENSION = ".hs";
+
+    private Constants() {}
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/DefaultIndenter.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/DefaultIndenter.java
@@ -1,0 +1,51 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.dataformat.xml.util.DefaultXmlPrettyPrinter.Indenter;
+import java.io.IOException;
+import javax.xml.stream.XMLStreamException;
+import org.apache.commons.lang3.StringUtils;
+import org.codehaus.stax2.XMLStreamWriter2;
+
+public class DefaultIndenter implements Indenter, java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final int NUMBER_OF_SPACES = 4;
+
+    @Override
+    public boolean isInline() {
+        return false;
+    }
+
+    @Override
+    public void writeIndentation(XMLStreamWriter2 sw, int level) throws XMLStreamException {
+        sw.writeRaw("\n");
+        sw.writeRaw(StringUtils.repeat(' ', NUMBER_OF_SPACES * level));
+    }
+
+    @Override
+    public void writeIndentation(JsonGenerator jg, int level) throws IOException {
+        jg.writeRaw("\n");
+        jg.writeRaw(StringUtils.repeat(' ', NUMBER_OF_SPACES * level));
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/AddOn.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/AddOn.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.io.Serializable;
+
+public class AddOn implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty public String id;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String version;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String semver;
+
+    @JacksonXmlProperty(localName = "not-before-version")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public Integer notBeforeVersion;
+
+    @JacksonXmlProperty(localName = "not-from-version")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public Integer notFromVersion;
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/Bundle.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/Bundle.java
@@ -1,0 +1,34 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+import java.io.Serializable;
+
+public class Bundle implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JacksonXmlProperty(isAttribute = true)
+    public String prefix;
+
+    @JacksonXmlText public String bundle;
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/Classnames.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/Classnames.java
@@ -1,0 +1,42 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import java.io.Serializable;
+import java.util.List;
+
+public class Classnames implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    @JacksonXmlElementWrapper(useWrapping = false)
+    public List<String> allowed;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    @JacksonXmlElementWrapper(useWrapping = false)
+    public List<String> restricted;
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/Dependencies.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/Dependencies.java
@@ -1,0 +1,42 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.io.Serializable;
+import java.util.List;
+
+public class Dependencies implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String javaversion;
+
+    @JacksonXmlElementWrapper(localName = "addons")
+    @JacksonXmlProperty(localName = "addon")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public List<AddOn> addOns;
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/DependenciesExt.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/DependenciesExt.java
@@ -1,0 +1,37 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.io.Serializable;
+import java.util.List;
+
+public class DependenciesExt implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JacksonXmlElementWrapper(localName = "addons")
+    @JacksonXmlProperty(localName = "addon")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public List<AddOn> addOns;
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/Extension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/Extension.java
@@ -1,0 +1,51 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.io.Serializable;
+
+public class Extension implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JacksonXmlProperty(localName = "v", isAttribute = true)
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String version;
+
+    @JsonProperty public String classname;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_NULL)
+    public Classnames classnames;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_NULL)
+    public DependenciesExt dependencies;
+
+    public Extension() {}
+
+    public Extension(String classname) {
+        this.classname = classname;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/ExtensionConverter.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/ExtensionConverter.java
@@ -1,0 +1,35 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+
+public class ExtensionConverter extends StdConverter<Extension, Object> {
+
+    @Override
+    public Object convert(Extension extension) {
+        if (!"1".equals(extension.version)) {
+            ExtensionNoDeps ext = new ExtensionNoDeps();
+            ext.extension = extension.classname;
+            return ext;
+        }
+        return extension;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/ExtensionNoDeps.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/ExtensionNoDeps.java
@@ -1,0 +1,30 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+import java.io.Serializable;
+
+public class ExtensionNoDeps implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JacksonXmlText public String extension;
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/Helpset.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/Helpset.java
@@ -1,0 +1,34 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+import java.io.Serializable;
+
+public class Helpset implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JacksonXmlProperty(isAttribute = true)
+    public String localetoken;
+
+    @JacksonXmlText public String helpset;
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/Manifest.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/Manifest.java
@@ -1,0 +1,108 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonRootName(value = "zapaddon")
+public class Manifest implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty public String name;
+
+    @JsonProperty public String version;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String semver;
+
+    @JsonProperty public String status;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String description;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String author;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String url;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String changes;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_NULL)
+    public Classnames classnames;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_NULL)
+    public Dependencies dependencies;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_NULL)
+    public Bundle bundle;
+
+    @JsonProperty
+    @JsonInclude(value = Include.NON_NULL)
+    public Helpset helpset;
+
+    @JacksonXmlElementWrapper(localName = "extensions")
+    @JacksonXmlProperty(localName = "extension")
+    @JsonSerialize(contentConverter = ExtensionConverter.class)
+    @JsonInclude(value = Include.NON_EMPTY)
+    public List<Extension> extensions = new ArrayList<>();
+
+    @JacksonXmlElementWrapper(localName = "ascanrules")
+    @JacksonXmlProperty(localName = "ascanrule")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public List<String> ascanrules = new ArrayList<>();
+
+    @JacksonXmlElementWrapper(localName = "pscanrules")
+    @JacksonXmlProperty(localName = "pscanrule")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public List<String> pscanrules = new ArrayList<>();
+
+    @JacksonXmlElementWrapper(localName = "files")
+    @JacksonXmlProperty(localName = "file")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public List<String> files = new ArrayList<>();
+
+    @JacksonXmlProperty(localName = "not-before-version")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String notBeforeVersion;
+
+    @JacksonXmlProperty(localName = "not-from-version")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String notFromVersion;
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/zapversions/AddOn.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/zapversions/AddOn.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model.zapversions;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import org.zaproxy.gradle.addon.internal.model.Dependencies;
+
+public class AddOn implements Comparable<AddOn>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonIgnore public String id;
+
+    public String name;
+    public String description;
+    public String author;
+    public String version;
+
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String semver;
+
+    public String file;
+    public String status;
+
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String changes;
+
+    public String url;
+    public String hash;
+
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String info;
+
+    public String date;
+    public String size;
+
+    @JsonProperty(value = "not-before-version")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String notBeforeVersion;
+
+    @JsonProperty(value = "not-from-version")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String notFromVersion;
+
+    @JsonProperty(value = "dependencies")
+    @JsonInclude(value = Include.NON_NULL)
+    public Dependencies dependencies;
+
+    @Override
+    public int compareTo(AddOn other) {
+        return id.compareTo(other.id);
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/zapversions/Core.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/zapversions/Core.java
@@ -1,0 +1,51 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model.zapversions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+
+public class Core implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public String version;
+
+    @JsonProperty(value = "daily-version")
+    public String dailyVersion;
+
+    @JsonProperty(value = "daily")
+    public Package daily;
+
+    @JsonProperty(value = "windows")
+    public Package windows;
+
+    @JsonProperty(value = "linux")
+    public Package linux;
+
+    @JsonProperty(value = "mac")
+    public Package mac;
+
+    @JsonProperty(value = "relnotes")
+    public String relnotes;
+
+    @JsonProperty(value = "relnotes-url")
+    public String relnotesUrl;
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/zapversions/Package.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/zapversions/Package.java
@@ -1,0 +1,32 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model.zapversions;
+
+import java.io.Serializable;
+
+public class Package implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public String url;
+    public String file;
+    public String hash;
+    public String size;
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/zapversions/ZapVersions.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/zapversions/ZapVersions.java
@@ -1,0 +1,46 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model.zapversions;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.Serializable;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+@JsonRootName(value = "ZAP")
+@JsonIgnoreProperties({"addon", "addOns"})
+@JsonSerialize(using = ZapVersionsSerializer.class)
+public class ZapVersions implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public Core core;
+
+    public SortedSet<AddOn> addOns = new TreeSet<>();
+
+    @JsonAnySetter
+    public void addAddOn(String name, AddOn addOn) {
+        addOn.id = name.substring(6);
+        addOns.add(addOn);
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/zapversions/ZapVersionsSerializer.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/zapversions/ZapVersionsSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.internal.model.zapversions;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
+public class ZapVersionsSerializer extends StdSerializer<ZapVersions> {
+
+    private static final long serialVersionUID = 1L;
+
+    protected ZapVersionsSerializer() {
+        super(ZapVersions.class);
+    }
+
+    @Override
+    public void serialize(ZapVersions value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        gen.writeStartObject();
+        if (value.core != null) {
+            gen.writeObjectField("core", value.core);
+        }
+        for (AddOn addOn : value.addOns) {
+            gen.writeObjectField("addon", addOn.id);
+            gen.writeObjectField("addon_" + addOn.id, addOn);
+        }
+        gen.writeEndObject();
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/jh/tasks/JavaHelpIndexer.java
+++ b/src/main/java/org/zaproxy/gradle/addon/jh/tasks/JavaHelpIndexer.java
@@ -1,0 +1,269 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.jh.tasks;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SourceTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.ExecResult;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+import org.zaproxy.gradle.addon.AddOnPluginException;
+
+/** Task that invokes {@code jhindexer}. */
+@CacheableTask
+public class JavaHelpIndexer extends SourceTask {
+
+    public static final String DEFAULT_DB_NAME = "JavaHelpSearch";
+
+    private static final String INDEXER_CLASSNAME = "com.sun.java.help.search.Indexer";
+
+    private static final XPathExpression LANG_HELP_SET_FILE_XPATH_EXPRESSION;
+
+    static {
+        String expression = "/helpset/@lang";
+        try {
+            LANG_HELP_SET_FILE_XPATH_EXPRESSION =
+                    XPathFactory.newInstance().newXPath().compile(expression);
+        } catch (XPathExpressionException e) {
+            throw new AddOnPluginException(
+                    "Failed to compile valid XPath expression: " + expression, e);
+        }
+    }
+
+    private static final String CONF_FILE_ARG = "-c";
+    private static final String DB_NAME_ARG = "-db";
+    private static final String LOCALE_ARG = "-locale";
+
+    private final RegularFileProperty helpset;
+
+    private final Property<String> dbName;
+    private final Property<String> outputPrefix;
+    private final ConfigurableFileCollection classpath;
+
+    private final DirectoryProperty destinationDir;
+
+    public JavaHelpIndexer() {
+        ObjectFactory objects = getProject().getObjects();
+        this.dbName = objects.property(String.class).value(DEFAULT_DB_NAME);
+        this.outputPrefix = objects.property(String.class);
+        this.classpath = getProject().files();
+        this.helpset = objects.fileProperty();
+        this.destinationDir = objects.directoryProperty();
+        include("**/*.html");
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public RegularFileProperty getHelpset() {
+        return helpset;
+    }
+
+    @Override
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public FileTree getSource() {
+        return super.getSource();
+    }
+
+    @Input
+    @Optional
+    public Property<String> getDbName() {
+        return dbName;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getOutputPrefix() {
+        return outputPrefix;
+    }
+
+    @OutputDirectory
+    public DirectoryProperty getDestinationDir() {
+        return destinationDir;
+    }
+
+    @Classpath
+    public ConfigurableFileCollection getClasspath() {
+        return classpath;
+    }
+
+    @TaskAction
+    public void generate() {
+        File helpsetFile = helpset.getAsFile().get();
+        String locale = readLocaleFromHelpSetFile(helpsetFile.toPath());
+
+        File wd = getWorkingDirectory();
+        prepareWorkingDirectory(wd);
+
+        File conf = new File(getTemporaryDir(), "jhindexer.conf");
+        createConfigFile(conf, getIndexPathPrefix(helpsetFile), getSource().getFiles());
+
+        List<String> args = new ArrayList<>();
+        args.add(LOCALE_ARG);
+        args.add(locale);
+        args.add(DB_NAME_ARG);
+        args.add(getDbName().get());
+        args.add(CONF_FILE_ARG);
+        args.add(conf.getAbsolutePath());
+
+        ExecResult result =
+                getProject()
+                        .javaexec(
+                                spec -> {
+                                    spec.setClasspath(classpath)
+                                            .setWorkingDir(wd.getAbsolutePath());
+                                    spec.setMain(INDEXER_CLASSNAME).args(args);
+                                    spec.setStandardOutput(System.out).setErrorOutput(System.err);
+                                });
+
+        result.assertNormalExitValue();
+    }
+
+    private static String getIndexPathPrefix(File helpset) {
+        String parent = normalisedPath(helpset.getParent());
+        if (parent == null) {
+            throw new AddOnPluginException(
+                    "The helpset file does not have a parent directory: " + helpset);
+        }
+        if (parent.endsWith("/")) {
+            return parent;
+        }
+        return parent + '/';
+    }
+
+    private static void createConfigFile(File configFile, String pathPrefix, Set<File> files) {
+        try (Writer w = Files.newBufferedWriter(configFile.toPath(), StandardCharsets.UTF_8)) {
+            w.write("IndexRemove ");
+            w.write(pathPrefix);
+            w.write('\n');
+            files.forEach(
+                    file -> {
+                        try {
+                            w.write("File ");
+                            w.write(normalisedPath(file));
+                            w.write('\n');
+                        } catch (IOException e) {
+                            throw new AddOnPluginException("", e);
+                        }
+                    });
+        } catch (IOException e) {
+            throw new AddOnPluginException("Failed to create: " + configFile, e);
+        }
+    }
+
+    private File getWorkingDirectory() {
+        Directory destDir = destinationDir.get();
+        String path = outputPrefix.getOrElse("");
+        return path.isEmpty() ? destDir.getAsFile() : destDir.dir(path).getAsFile();
+    }
+
+    private void prepareWorkingDirectory(File wd) {
+        getProject().delete(wd);
+        try {
+            Files.createDirectories(wd.toPath());
+        } catch (IOException e) {
+            throw new AddOnPluginException("Failed to create destination directory: " + wd, e);
+        }
+    }
+
+    private String readLocaleFromHelpSetFile(Path helpSetFile) {
+        if (!Files.exists(helpSetFile)) {
+            throw new AddOnPluginException(
+                    "Required helpset file does not exist: "
+                            + helpSetFile.toAbsolutePath().toString());
+        }
+
+        String language;
+        try (InputStream inputStream = new BufferedInputStream(Files.newInputStream(helpSetFile))) {
+            DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+            builderFactory.setValidating(false);
+            builderFactory.setFeature(
+                    "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            builderFactory.setFeature(
+                    "http://xml.org/sax/features/external-general-entities", false);
+            builderFactory.setFeature(
+                    "http://xml.org/sax/features/external-parameter-entities", false);
+            Document doc = builderFactory.newDocumentBuilder().parse(inputStream);
+
+            language =
+                    (String)
+                            LANG_HELP_SET_FILE_XPATH_EXPRESSION.evaluate(
+                                    doc, XPathConstants.STRING);
+        } catch (SAXException
+                | ParserConfigurationException
+                | IOException
+                | XPathExpressionException e) {
+            throw new AddOnPluginException(
+                    "Failed to extract xml:lang attribute from helpset file: "
+                            + helpSetFile.toAbsolutePath().toString(),
+                    e);
+        }
+
+        if (language == null || language.isEmpty()) {
+            throw new AddOnPluginException(
+                    "Required helpset xml:lang attribute not found or empty in: "
+                            + helpSetFile.toAbsolutePath().toString());
+        }
+
+        return language.replace('-', '_');
+    }
+
+    private static String normalisedPath(File file) {
+        return normalisedPath(file.getAbsolutePath());
+    }
+
+    private static String normalisedPath(String path) {
+        if (path != null && File.separatorChar != '/') {
+            return path.replace(File.separatorChar, '/');
+        }
+        return path;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/AddOn.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/AddOn.java
@@ -1,0 +1,82 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest;
+
+import javax.inject.Inject;
+import org.gradle.api.Named;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+
+public class AddOn implements Named {
+
+    private final String id;
+
+    private final Property<String> version;
+    private final Property<String> semVer;
+    private final Property<Integer> notBeforeVersion;
+    private final Property<Integer> notFromVersion;
+
+    @Inject
+    public AddOn(String id, ObjectFactory objectFactory) {
+        this.id = id;
+        this.version = objectFactory.property(String.class);
+        this.semVer = objectFactory.property(String.class);
+        this.notBeforeVersion = objectFactory.property(Integer.class);
+        this.notFromVersion = objectFactory.property(Integer.class);
+    }
+
+    @Internal
+    @Override
+    public String getName() {
+        return getId();
+    }
+
+    @Input
+    public String getId() {
+        return id;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getVersion() {
+        return version;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getSemVer() {
+        return semVer;
+    }
+
+    @Input
+    @Optional
+    public Property<Integer> getNotBeforeVersion() {
+        return notBeforeVersion;
+    }
+
+    @Input
+    @Optional
+    public Property<Integer> getNotFromVersion() {
+        return notFromVersion;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/Bundle.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/Bundle.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest;
+
+import javax.inject.Inject;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+
+public class Bundle {
+
+    private final Property<String> baseName;
+    private final Property<String> prefix;
+
+    @Inject
+    public Bundle(ObjectFactory objectFactory) {
+        this.baseName = objectFactory.property(String.class);
+        this.prefix = objectFactory.property(String.class);
+    }
+
+    @Input
+    public Property<String> getBaseName() {
+        return baseName;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getPrefix() {
+        return prefix;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/Classnames.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/Classnames.java
@@ -1,0 +1,50 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest;
+
+import javax.inject.Inject;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+
+public class Classnames {
+
+    private final ListProperty<String> allowed;
+    private final ListProperty<String> restricted;
+
+    @Inject
+    public Classnames(ObjectFactory objectFactory) {
+        this.allowed = objectFactory.listProperty(String.class);
+        this.restricted = objectFactory.listProperty(String.class);
+    }
+
+    @Input
+    @Optional
+    public ListProperty<String> getAllowed() {
+        return allowed;
+    }
+
+    @Input
+    @Optional
+    public ListProperty<String> getRestricted() {
+        return restricted;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/Dependencies.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/Dependencies.java
@@ -1,0 +1,67 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest;
+
+import groovy.lang.Closure;
+import javax.inject.Inject;
+import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+
+public class Dependencies {
+
+    private final Property<String> javaVersion;
+    private final NamedDomainObjectContainer<AddOn> addOns;
+
+    @Inject
+    public Dependencies(Project project) {
+        this.javaVersion = project.getObjects().property(String.class);
+        this.addOns = project.container(AddOn.class, id -> new AddOn(id, project.getObjects()));
+    }
+
+    @Input
+    @Optional
+    public Property<String> getJavaVersion() {
+        return javaVersion;
+    }
+
+    @Nested
+    public Iterable<AddOn> getAddOnsIterable() {
+        return getAddOns();
+    }
+
+    @Internal
+    public NamedDomainObjectContainer<AddOn> getAddOns() {
+        return addOns;
+    }
+
+    public void addOns(Action<? super NamedDomainObjectContainer<AddOn>> action) {
+        action.execute(addOns);
+    }
+
+    public void addOns(Closure<?> action) {
+        addOns.configure(action);
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/Extension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/Extension.java
@@ -1,0 +1,133 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest;
+
+import groovy.lang.Closure;
+import javax.inject.Inject;
+import org.gradle.api.Action;
+import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+
+public class Extension implements Named {
+
+    private final String classname;
+    private final Project project;
+    private final Property<Classnames> classnames;
+    private final Property<Dependencies> dependencies;
+
+    @Inject
+    public Extension(String classname, Project project) {
+        this.classname = classname;
+        this.project = project;
+
+        ObjectFactory objectFactory = project.getObjects();
+        this.classnames = objectFactory.property(Classnames.class);
+        this.dependencies = objectFactory.property(Dependencies.class);
+    }
+
+    @Internal
+    @Override
+    public String getName() {
+        return getClassname();
+    }
+
+    @Input
+    public String getClassname() {
+        return classname;
+    }
+
+    @Nested
+    @Optional
+    public Property<Classnames> getClassnames() {
+        return classnames;
+    }
+
+    public void classnames(Action<? super Classnames> action) {
+        if (!classnames.isPresent()) {
+            classnames.set(
+                    project.getObjects().newInstance(Classnames.class, project.getObjects()));
+        }
+        action.execute(classnames.get());
+    }
+
+    public void classnames(Closure<? super Classnames> c) {
+        if (!classnames.isPresent()) {
+            classnames.set(
+                    project.getObjects().newInstance(Classnames.class, project.getObjects()));
+        }
+        call(c, classnames.get());
+    }
+
+    private static <T> void call(Closure<? super T> c, T value) {
+        c.setDelegate(value);
+        c.call(value);
+    }
+
+    @Nested
+    @Optional
+    public Property<Dependencies> getDependencies() {
+        return dependencies;
+    }
+
+    public void dependencies(Action<? super Dependencies> action) {
+        if (!dependencies.isPresent()) {
+            dependencies.set(project.getObjects().newInstance(Dependencies.class, project));
+        }
+        action.execute(dependencies.get());
+    }
+
+    public void dependencies(Closure<? super Dependencies> c) {
+        if (!dependencies.isPresent()) {
+            dependencies.set(project.getObjects().newInstance(Dependencies.class, project));
+        }
+        call(c, dependencies.get());
+    }
+
+    public static class Dependencies {
+
+        private final NamedDomainObjectContainer<AddOn> addOns;
+
+        @Inject
+        public Dependencies(Project project) {
+            this.addOns = project.container(AddOn.class, id -> new AddOn(id, project.getObjects()));
+        }
+
+        @Nested
+        public Iterable<AddOn> getAddOnsIterable() {
+            return getAddOns();
+        }
+
+        @Internal
+        public NamedDomainObjectContainer<AddOn> getAddOns() {
+            return addOns;
+        }
+
+        public void addOns(Action<? super NamedDomainObjectContainer<AddOn>> action) {
+            action.execute(addOns);
+        }
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/HelpSet.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/HelpSet.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest;
+
+import javax.inject.Inject;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+
+public class HelpSet {
+
+    private final Property<String> baseName;
+    private final Property<String> localeToken;
+
+    @Inject
+    public HelpSet(ObjectFactory objectFactory) {
+        this.baseName = objectFactory.property(String.class);
+        this.localeToken = objectFactory.property(String.class);
+    }
+
+    @Input
+    public Property<String> getBaseName() {
+        return baseName;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getLocaleToken() {
+        return localeToken;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/ManifestExtension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/ManifestExtension.java
@@ -1,0 +1,196 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest;
+
+import javax.inject.Inject;
+import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+
+public class ManifestExtension {
+
+    private final Property<String> semVer;
+    private final Property<String> description;
+    private final Property<String> author;
+    private final Property<String> url;
+    private final Property<String> changes;
+    private final RegularFileProperty changesFile;
+    private final Property<Dependencies> dependencies;
+    private final Property<Bundle> bundle;
+    private final Property<HelpSet> helpSet;
+    private final Property<Classnames> classnames;
+    private NamedDomainObjectContainer<Extension> extensions;
+    private NamedDomainObjectContainer<ScanRule> ascanrules;
+    private NamedDomainObjectContainer<ScanRule> pscanrules;
+    private final ConfigurableFileCollection files;
+    private final Property<String> notBeforeVersion;
+    private final Property<String> notFromVersion;
+
+    private final ConfigurableFileCollection classpath;
+
+    private final DirectoryProperty outputDir;
+
+    private final Project project;
+
+    @Inject
+    public ManifestExtension(Project project) {
+        this.project = project;
+        ObjectFactory objects = project.getObjects();
+
+        this.semVer = objects.property(String.class);
+        this.description = objects.property(String.class);
+        this.description.set(project.provider(project::getDescription));
+        this.author = objects.property(String.class);
+        this.url = objects.property(String.class);
+        this.changes = objects.property(String.class);
+        this.changesFile = objects.fileProperty();
+        this.dependencies = objects.property(Dependencies.class);
+        this.bundle = objects.property(Bundle.class);
+        this.helpSet = objects.property(HelpSet.class);
+        this.classnames = objects.property(Classnames.class);
+        this.extensions =
+                project.container(Extension.class, classname -> new Extension(classname, project));
+        this.ascanrules = project.container(ScanRule.class, ScanRule::new);
+        this.pscanrules = project.container(ScanRule.class, ScanRule::new);
+        this.files = project.files();
+        this.notBeforeVersion = objects.property(String.class);
+        this.notFromVersion = objects.property(String.class);
+        this.classpath = project.files();
+        this.outputDir = objects.directoryProperty();
+    }
+
+    public Property<String> getSemVer() {
+        return semVer;
+    }
+
+    public Property<String> getDescription() {
+        return description;
+    }
+
+    public Property<String> getAuthor() {
+        return author;
+    }
+
+    public Property<String> getUrl() {
+        return url;
+    }
+
+    public Property<String> getChanges() {
+        return changes;
+    }
+
+    public RegularFileProperty getChangesFile() {
+        return changesFile;
+    }
+
+    public Property<Dependencies> getDependencies() {
+        return dependencies;
+    }
+
+    public void dependencies(Action<? super Dependencies> action) {
+        if (!dependencies.isPresent()) {
+            dependencies.set(project.getObjects().newInstance(Dependencies.class, project));
+        }
+        action.execute(dependencies.get());
+    }
+
+    public Property<Bundle> getBundle() {
+        return bundle;
+    }
+
+    public void bundle(Action<? super Bundle> action) {
+        if (!bundle.isPresent()) {
+            bundle.set(project.getObjects().newInstance(Bundle.class, project.getObjects()));
+        }
+        action.execute(bundle.get());
+    }
+
+    public Property<HelpSet> getHelpSet() {
+        return helpSet;
+    }
+
+    public void helpSet(Action<? super HelpSet> action) {
+        if (!helpSet.isPresent()) {
+            helpSet.set(project.getObjects().newInstance(HelpSet.class, project.getObjects()));
+        }
+        action.execute(helpSet.get());
+    }
+
+    public Property<Classnames> getClassnames() {
+        return classnames;
+    }
+
+    public void classnames(Action<? super Classnames> action) {
+        if (!classnames.isPresent()) {
+            classnames.set(
+                    project.getObjects().newInstance(Classnames.class, project.getObjects()));
+        }
+        action.execute(classnames.get());
+    }
+
+    public NamedDomainObjectContainer<Extension> getAddOnExtensions() {
+        return extensions;
+    }
+
+    public void extensions(Action<? super NamedDomainObjectContainer<Extension>> action) {
+        action.execute(extensions);
+    }
+
+    public NamedDomainObjectContainer<ScanRule> getAscanrules() {
+        return ascanrules;
+    }
+
+    public void ascanrules(Action<? super NamedDomainObjectContainer<ScanRule>> action) {
+        action.execute(ascanrules);
+    }
+
+    public NamedDomainObjectContainer<ScanRule> getPscanrules() {
+        return pscanrules;
+    }
+
+    public void pscanrules(Action<? super NamedDomainObjectContainer<ScanRule>> action) {
+        action.execute(pscanrules);
+    }
+
+    public ConfigurableFileCollection getFiles() {
+        return files;
+    }
+
+    public Property<String> getNotBeforeVersion() {
+        return notBeforeVersion;
+    }
+
+    public Property<String> getNotFromVersion() {
+        return notFromVersion;
+    }
+
+    public ConfigurableFileCollection getClasspath() {
+        return classpath;
+    }
+
+    public DirectoryProperty getOutputDir() {
+        return outputDir;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/ScanRule.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/ScanRule.java
@@ -1,0 +1,46 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest;
+
+import javax.inject.Inject;
+import org.gradle.api.Named;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+
+public class ScanRule implements Named {
+
+    private final String classname;
+
+    @Inject
+    public ScanRule(String classname) {
+        this.classname = classname;
+    }
+
+    @Internal
+    @Override
+    public String getName() {
+        return getClassname();
+    }
+
+    @Input
+    public String getClassname() {
+        return classname;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/tasks/ConvertChangelogToChanges.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/tasks/ConvertChangelogToChanges.java
@@ -1,0 +1,136 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest.tasks;
+
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughSubscriptExtension;
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.options.MutableDataSet;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+/** A task that converts a changelog (in Keep a Changelog format) to manifest changes (HTML). */
+public class ConvertChangelogToChanges extends DefaultTask {
+
+    private static final int CHANGELOG_CHUNK_SIZE = 20_000;
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(?m)^## \\[?.+]?.*\\R");
+    private static final Pattern VERSION_LINK_PATTERN = Pattern.compile("(?m)^\\[.+]:");
+
+    private final RegularFileProperty changelog;
+    private final RegularFileProperty manifestChanges;
+
+    public ConvertChangelogToChanges() {
+        ObjectFactory objects = getProject().getObjects();
+        changelog = objects.fileProperty();
+        manifestChanges = objects.fileProperty();
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getChangelog() {
+        return changelog;
+    }
+
+    @OutputFile
+    public RegularFileProperty getManifestChanges() {
+        return manifestChanges;
+    }
+
+    @TaskAction
+    public void convert() throws IOException {
+        MutableDataSet options =
+                new MutableDataSet()
+                        .set(TablesExtension.COLUMN_SPANS, false)
+                        .set(TablesExtension.APPEND_MISSING_COLUMNS, true)
+                        .set(TablesExtension.DISCARD_EXTRA_COLUMNS, true)
+                        .set(TablesExtension.HEADER_SEPARATOR_COLUMN_MATCH, true)
+                        .set(
+                                Parser.EXTENSIONS,
+                                Arrays.asList(
+                                        StrikethroughSubscriptExtension.create(),
+                                        TablesExtension.create(),
+                                        TaskListExtension.create()));
+
+        Parser parser = Parser.builder(options).build();
+        HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+
+        String changes = getChanges(changelog.get().getAsFile().toPath());
+        try (Writer writer = Files.newBufferedWriter(manifestChanges.get().getAsFile().toPath())) {
+            renderer.render(parser.parse(changes), writer);
+        }
+    }
+
+    private String getChanges(Path changelog) throws IOException {
+        return extractChangesLatestVersion(readChunk(changelog));
+    }
+
+    private static String readChunk(Path changelog) throws IOException {
+        char[] chars = new char[CHANGELOG_CHUNK_SIZE];
+        int n;
+        try (Reader reader = Files.newBufferedReader(changelog)) {
+            n = reader.read(chars);
+        }
+        if (n == -1) {
+            throw new IOException("Failed to read any characters from: " + changelog);
+        }
+        return new String(chars, 0, n);
+    }
+
+    private String extractChangesLatestVersion(String contents) {
+        Matcher matcher = VERSION_PATTERN.matcher(contents);
+        if (!matcher.find()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "No version matching '%1s' was found in changelog:%n%2s",
+                            VERSION_PATTERN, contents));
+        }
+        int changesStart = matcher.end();
+        int changesEnd = contents.length();
+        if (matcher.find()) {
+            changesEnd = matcher.start();
+        } else {
+            getLogger().debug("Second version not found, using version link.");
+            matcher = VERSION_LINK_PATTERN.matcher(contents);
+            if (matcher.find()) {
+                changesEnd = matcher.start();
+            } else {
+                getLogger().debug("Version link not found, defaulting to end of contents.");
+            }
+        }
+        return contents.substring(changesStart, changesEnd);
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/tasks/GenerateManifestFile.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/tasks/GenerateManifestFile.java
@@ -1,0 +1,579 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest.tasks;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.util.DefaultXmlPrettyPrinter;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.MethodInfo;
+import io.github.classgraph.ScanResult;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.gradle.addon.AddOnStatus;
+import org.zaproxy.gradle.addon.internal.Constants;
+import org.zaproxy.gradle.addon.internal.DefaultIndenter;
+import org.zaproxy.gradle.addon.manifest.Bundle;
+import org.zaproxy.gradle.addon.manifest.Classnames;
+import org.zaproxy.gradle.addon.manifest.Dependencies;
+import org.zaproxy.gradle.addon.manifest.Extension;
+import org.zaproxy.gradle.addon.manifest.HelpSet;
+import org.zaproxy.gradle.addon.manifest.ScanRule;
+
+/** A task that generates the manifest ({@code ZapAddOn.xml}) for a given add-on. */
+@CacheableTask
+public class GenerateManifestFile extends DefaultTask {
+
+    private final Property<String> addOnName;
+    private final Property<String> version;
+    private final Property<String> semVer;
+    private final Property<AddOnStatus> status;
+    private final Property<String> addOnDescription;
+    private final Property<String> author;
+    private final Property<String> url;
+    private final Property<String> changes;
+    private final RegularFileProperty changesFile;
+    private final Property<Dependencies> dependencies;
+    private final Property<Bundle> bundle;
+    private final Property<HelpSet> helpSet;
+    private final Property<Classnames> classnames;
+    private NamedDomainObjectContainer<Extension> extensions;
+    private NamedDomainObjectContainer<ScanRule> ascanrules;
+    private NamedDomainObjectContainer<ScanRule> pscanrules;
+    private final ConfigurableFileCollection files;
+    private final Property<String> notBeforeVersion;
+    private final Property<String> notFromVersion;
+
+    private final ConfigurableFileCollection classpath;
+
+    private final DirectoryProperty outputDir;
+    private final Provider<RegularFile> manifest;
+
+    public GenerateManifestFile() {
+        ObjectFactory objects = getProject().getObjects();
+        this.addOnName = objects.property(String.class);
+        this.version = objects.property(String.class);
+        this.version.set(getProject().provider(() -> getProject().getVersion().toString()));
+        this.semVer = objects.property(String.class);
+        this.status = objects.property(AddOnStatus.class).value(AddOnStatus.ALPHA);
+        this.addOnDescription = objects.property(String.class);
+        this.addOnDescription.set(getProject().provider(getProject()::getDescription));
+        this.author = objects.property(String.class);
+        this.url = objects.property(String.class);
+        this.changes = objects.property(String.class);
+        this.changesFile = objects.fileProperty();
+        this.dependencies = objects.property(Dependencies.class);
+        this.bundle = objects.property(Bundle.class);
+        this.helpSet = objects.property(HelpSet.class);
+        this.classnames = objects.property(Classnames.class);
+        this.extensions =
+                getProject()
+                        .container(
+                                Extension.class,
+                                classname -> new Extension(classname, getProject()));
+        this.ascanrules = getProject().container(ScanRule.class, ScanRule::new);
+        this.pscanrules = getProject().container(ScanRule.class, ScanRule::new);
+        this.files = getProject().files();
+        this.notBeforeVersion = objects.property(String.class);
+        this.notFromVersion = objects.property(String.class);
+        this.classpath = getProject().files();
+        this.outputDir = objects.directoryProperty();
+        this.manifest = outputDir.map(dir -> dir.file(Constants.ADD_ON_MANIFEST_FILE_NAME));
+    }
+
+    @Input
+    public Property<String> getAddOnName() {
+        return addOnName;
+    }
+
+    @Input
+    public Property<String> getVersion() {
+        return version;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getSemVer() {
+        return semVer;
+    }
+
+    @Input
+    public Property<AddOnStatus> getStatus() {
+        return status;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getAddOnDescription() {
+        return addOnDescription;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getAuthor() {
+        return author;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getUrl() {
+        return url;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getChanges() {
+        return changes;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    @Optional
+    public RegularFileProperty getChangesFile() {
+        return changesFile;
+    }
+
+    @Nested
+    @Optional
+    public Property<Dependencies> getDependencies() {
+        return dependencies;
+    }
+
+    @Nested
+    @Optional
+    public Property<Bundle> getBundle() {
+        return bundle;
+    }
+
+    @Nested
+    @Optional
+    public Property<HelpSet> getHelpSet() {
+        return helpSet;
+    }
+
+    @Nested
+    @Optional
+    public Property<Classnames> getClassnames() {
+        return classnames;
+    }
+
+    @Nested
+    @Optional
+    public Iterable<Extension> getAddOnExtensions() {
+        return new ArrayList<>(extensions);
+    }
+
+    public void setExtensions(NamedDomainObjectContainer<Extension> extensions) {
+        this.extensions = extensions;
+    }
+
+    public void extensions(Action<? super NamedDomainObjectContainer<Extension>> action) {
+        action.execute(extensions);
+    }
+
+    @Nested
+    @Optional
+    public Iterable<ScanRule> getAscanrules() {
+        return new ArrayList<>(ascanrules);
+    }
+
+    public void setAscanrules(NamedDomainObjectContainer<ScanRule> ascanrules) {
+        this.ascanrules = ascanrules;
+    }
+
+    public void ascanrules(Action<? super NamedDomainObjectContainer<ScanRule>> action) {
+        action.execute(ascanrules);
+    }
+
+    @Nested
+    @Optional
+    public Iterable<ScanRule> getPscanrules() {
+        return new ArrayList<>(pscanrules);
+    }
+
+    public void setPscanrules(NamedDomainObjectContainer<ScanRule> pscanrules) {
+        this.pscanrules = pscanrules;
+    }
+
+    public void pscanrules(Action<? super NamedDomainObjectContainer<ScanRule>> action) {
+        action.execute(pscanrules);
+    }
+
+    @InputFiles
+    @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public ConfigurableFileCollection getFiles() {
+        return files;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getNotBeforeVersion() {
+        return notBeforeVersion;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getNotFromVersion() {
+        return notFromVersion;
+    }
+
+    @InputFiles
+    @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public ConfigurableFileCollection getClasspath() {
+        return classpath;
+    }
+
+    public void dependencies(Action<? super Dependencies> action) {
+        if (!dependencies.isPresent()) {
+            dependencies.set(
+                    getProject().getObjects().newInstance(Dependencies.class, getProject()));
+        }
+        action.execute(dependencies.get());
+    }
+
+    public void bundle(Action<? super Bundle> action) {
+        if (!bundle.isPresent()) {
+            bundle.set(
+                    getProject().getObjects().newInstance(Bundle.class, getProject().getObjects()));
+        }
+        action.execute(bundle.get());
+    }
+
+    public void helpSet(Action<? super HelpSet> action) {
+        if (!helpSet.isPresent()) {
+            helpSet.set(
+                    getProject()
+                            .getObjects()
+                            .newInstance(HelpSet.class, getProject().getObjects()));
+        }
+        action.execute(helpSet.get());
+    }
+
+    public void classnames(Action<? super Classnames> action) {
+        if (!classnames.isPresent()) {
+            classnames.set(
+                    getProject()
+                            .getObjects()
+                            .newInstance(Classnames.class, getProject().getObjects()));
+        }
+        action.execute(classnames.get());
+    }
+
+    @Internal
+    public DirectoryProperty getOutputDir() {
+        return outputDir;
+    }
+
+    @OutputFile
+    public Provider<RegularFile> getManifest() {
+        return manifest;
+    }
+
+    @TaskAction
+    public void generate() throws IOException {
+        if ("unspecified".equals(version.get())) {
+            throw new InvalidUserDataException("No version specified for the add-on.");
+        }
+
+        if (getChangesFile().isPresent() && getChanges().isPresent()) {
+            throw new InvalidUserDataException("Only one type of changes property must be set.");
+        }
+
+        try (Writer w = Files.newBufferedWriter(getManifest().get().getAsFile().toPath())) {
+            DefaultXmlPrettyPrinter.Indenter indenter = new DefaultIndenter();
+            DefaultXmlPrettyPrinter printer = new DefaultXmlPrettyPrinter();
+            printer.indentObjectsWith(indenter);
+            printer.indentArraysWith(indenter);
+
+            XmlMapper mapper = new XmlMapper();
+            mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+            mapper.writer(printer).writeValue(w, createManifest());
+        }
+    }
+
+    private org.zaproxy.gradle.addon.internal.model.Manifest createManifest() throws IOException {
+        org.zaproxy.gradle.addon.internal.model.Manifest manifest =
+                new org.zaproxy.gradle.addon.internal.model.Manifest();
+        manifest.name = getAddOnName().get();
+        manifest.version = getVersion().get();
+        manifest.semver = getSemVer().getOrNull();
+        manifest.status = getStatus().get().toString();
+        manifest.description = getAddOnDescription().getOrNull();
+        manifest.author = getAuthor().getOrNull();
+        manifest.url = getUrl().getOrNull();
+        manifest.changes =
+                getChangesFile().isPresent()
+                        ? readContents(getChangesFile().getAsFile().get().toPath())
+                        : getChanges().getOrNull();
+
+        if (getDependencies().isPresent()) {
+            Dependencies dep = getDependencies().get();
+            manifest.dependencies = new org.zaproxy.gradle.addon.internal.model.Dependencies();
+            if (dep.getJavaVersion().isPresent()) {
+                manifest.dependencies.javaversion = dep.getJavaVersion().get();
+            }
+            if (!dep.getAddOns().isEmpty()) {
+                manifest.dependencies.addOns = new ArrayList<>();
+                dep.getAddOns()
+                        .forEach(
+                                e -> {
+                                    org.zaproxy.gradle.addon.internal.model.AddOn addOnSer =
+                                            new org.zaproxy.gradle.addon.internal.model.AddOn();
+                                    addOnSer.id = e.getId();
+                                    addOnSer.version = e.getVersion().getOrNull();
+                                    addOnSer.semver = e.getSemVer().getOrNull();
+                                    if (e.getNotBeforeVersion().isPresent()) {
+                                        int value = e.getNotBeforeVersion().get();
+                                        if (value != 0) {
+                                            addOnSer.notBeforeVersion = value;
+                                        }
+                                    }
+                                    if (e.getNotFromVersion().isPresent()) {
+                                        int value = e.getNotFromVersion().get();
+                                        if (value != 0) {
+                                            addOnSer.notFromVersion = value;
+                                        }
+                                    }
+                                    manifest.dependencies.addOns.add(addOnSer);
+                                });
+            }
+        }
+
+        if (getClassnames().isPresent()) {
+            Classnames names = getClassnames().get();
+            List<String> allowed = names.getAllowed().getOrElse(Collections.emptyList());
+            List<String> restricted = names.getRestricted().getOrElse(Collections.emptyList());
+            if (!allowed.isEmpty() || !restricted.isEmpty()) {
+                manifest.classnames = new org.zaproxy.gradle.addon.internal.model.Classnames();
+                manifest.classnames.allowed = allowed;
+                manifest.classnames.restricted = restricted;
+            }
+        }
+
+        if (getBundle().isPresent()) {
+            Bundle bundle1 = getBundle().get();
+            manifest.bundle = new org.zaproxy.gradle.addon.internal.model.Bundle();
+            manifest.bundle.bundle = bundle1.getBaseName().get();
+            manifest.bundle.prefix = bundle1.getPrefix().getOrNull();
+        }
+
+        if (getHelpSet().isPresent()) {
+            HelpSet helpSet1 = getHelpSet().get();
+            manifest.helpset = new org.zaproxy.gradle.addon.internal.model.Helpset();
+            manifest.helpset.helpset = helpSet1.getBaseName().get();
+            manifest.helpset.localetoken = helpSet1.getLocaleToken().getOrNull();
+        }
+
+        final List<String> extensionsClasspath = new ArrayList<>();
+        final List<String> ascanrulesClasspath = new ArrayList<>();
+        final List<String> pscanrulesClasspath = new ArrayList<>();
+        if (!classpath.isEmpty()) {
+            try (ScanResult scanResult =
+                    new ClassGraph().overrideClasspath(classpath).enableAllInfo().scan()) {
+                addSubclasses(
+                        extensionsClasspath,
+                        scanResult,
+                        "org.parosproxy.paros.extension.Extension",
+                        "org.parosproxy.paros.extension.ExtensionAdaptor");
+                addSubclasses(
+                        ascanrulesClasspath,
+                        scanResult,
+                        "org.parosproxy.paros.core.scanner.AbstractPlugin",
+                        "org.parosproxy.paros.core.scanner.AbstractHostPlugin",
+                        "org.parosproxy.paros.core.scanner.AbstractAppPlugin",
+                        "org.parosproxy.paros.core.scanner.AbstractAppParamPlugin");
+                addSubclasses(
+                        pscanrulesClasspath,
+                        scanResult,
+                        "org.zaproxy.zap.extension.pscan.PluginPassiveScanner");
+            }
+        }
+
+        if (!extensions.isEmpty() || !extensionsClasspath.isEmpty()) {
+            manifest.extensions = new ArrayList<>();
+            extensions.forEach(
+                    e -> {
+                        extensionsClasspath.remove(e.getClassname());
+                        org.zaproxy.gradle.addon.internal.model.Extension extSer =
+                                new org.zaproxy.gradle.addon.internal.model.Extension(
+                                        e.getClassname());
+                        if (e.getClassnames().isPresent()) {
+                            Classnames names = e.getClassnames().get();
+                            List<String> allowed =
+                                    names.getAllowed().getOrElse(Collections.emptyList());
+                            List<String> restricted =
+                                    names.getRestricted().getOrElse(Collections.emptyList());
+                            if (!allowed.isEmpty() || !restricted.isEmpty()) {
+                                extSer.classnames =
+                                        new org.zaproxy.gradle.addon.internal.model.Classnames();
+                                extSer.classnames.allowed = allowed;
+                                extSer.classnames.restricted = restricted;
+                                extSer.version = "1";
+                            }
+                        }
+                        if (e.getDependencies().isPresent()) {
+                            Extension.Dependencies dep = e.getDependencies().get();
+                            if (!dep.getAddOns().isEmpty()) {
+                                extSer.dependencies =
+                                        new org.zaproxy.gradle.addon.internal.model
+                                                .DependenciesExt();
+                                extSer.dependencies.addOns = new ArrayList<>();
+                                dep.getAddOns()
+                                        .forEach(
+                                                addOn -> {
+                                                    org.zaproxy.gradle.addon.internal.model.AddOn
+                                                            addOnSer =
+                                                                    new org.zaproxy.gradle.addon
+                                                                            .internal.model.AddOn();
+                                                    addOnSer.id = addOn.getId();
+                                                    if (addOn.getVersion().isPresent()) {
+                                                        addOnSer.version = addOn.getVersion().get();
+                                                    }
+                                                    if (addOn.getSemVer().isPresent()) {
+                                                        addOnSer.semver = addOn.getSemVer().get();
+                                                    }
+                                                    if (addOn.getNotBeforeVersion().isPresent()) {
+                                                        int value =
+                                                                addOn.getNotBeforeVersion().get();
+                                                        if (value != 0) {
+                                                            addOnSer.notBeforeVersion = value;
+                                                        }
+                                                    }
+                                                    if (addOn.getNotFromVersion().isPresent()) {
+                                                        int value = addOn.getNotFromVersion().get();
+                                                        if (value != 0) {
+                                                            addOnSer.notFromVersion = value;
+                                                        }
+                                                    }
+                                                    extSer.dependencies.addOns.add(addOnSer);
+                                                });
+                                extSer.version = "1";
+                            }
+                        }
+                        manifest.extensions.add(extSer);
+                    });
+            extensionsClasspath.forEach(
+                    classname ->
+                            manifest.extensions.add(
+                                    new org.zaproxy.gradle.addon.internal.model.Extension(
+                                            classname)));
+            manifest.extensions.sort(Comparator.comparing(e -> e.classname));
+        }
+
+        if (!ascanrules.isEmpty() || !ascanrulesClasspath.isEmpty()) {
+            manifest.ascanrules = new ArrayList<>();
+            ascanrules.forEach(e -> manifest.ascanrules.add(e.getClassname()));
+            ascanrulesClasspath.stream()
+                    .filter(e -> !manifest.ascanrules.contains(e))
+                    .forEach(manifest.ascanrules::add);
+            Collections.sort(manifest.ascanrules);
+        }
+
+        if (!pscanrules.isEmpty() || !pscanrulesClasspath.isEmpty()) {
+            manifest.pscanrules = new ArrayList<>();
+            pscanrules.forEach(e -> manifest.pscanrules.add(e.getClassname()));
+            pscanrulesClasspath.stream()
+                    .filter(e -> !manifest.pscanrules.contains(e))
+                    .forEach(manifest.pscanrules::add);
+            Collections.sort(manifest.pscanrules);
+        }
+
+        if (!getFiles().isEmpty()) {
+            List<String> paths = new ArrayList<>();
+            getFiles()
+                    .getAsFileTree()
+                    .visit(
+                            details -> {
+                                if (!details.isDirectory()) {
+                                    paths.add(details.getRelativePath().toString());
+                                }
+                            });
+            Collections.sort(paths);
+            manifest.files = paths;
+        }
+
+        if (getNotBeforeVersion().isPresent()) {
+            manifest.notBeforeVersion = getNotBeforeVersion().get();
+        }
+        if (getNotFromVersion().isPresent()) {
+            manifest.notFromVersion = getNotFromVersion().get();
+        }
+        return manifest;
+    }
+
+    private void addSubclasses(List<String> list, ScanResult scanResult, String... classnames) {
+        scanResult.getAllStandardClasses()
+                .filter(
+                        ci ->
+                                ci.isPublic()
+                                        && !ci.isAbstract()
+                                        && ci.getSuperclasses().stream()
+                                                .map(ClassInfo::getName)
+                                                .anyMatch(
+                                                        name ->
+                                                                StringUtils.equalsAny(
+                                                                        name, classnames))
+                                        && !ci.getDeclaredConstructorInfo()
+                                                .filter(MethodInfo::isConstructor)
+                                                .filter(MethodInfo::isPublic)
+                                                .filter(mi -> mi.getParameterInfo().length == 0)
+                                                .isEmpty())
+                .stream()
+                .map(ClassInfo::getName)
+                .collect(() -> list, List::add, List::addAll);
+    }
+
+    private static String readContents(Path file) throws IOException {
+        return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/misc/CopyAddOn.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/CopyAddOn.java
@@ -1,0 +1,109 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.misc;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.options.Option;
+import org.zaproxy.gradle.addon.internal.Constants;
+
+/**
+ * A task to copy the add-on to a directory.
+ *
+ * <p>Defaults to {@code $rootDir/../zaproxy/src/plugin/}.
+ *
+ * <p>Existing add-ons with the same ID are removed from the destination directory before copying
+ * the add-on, to ensure ZAP uses the copied add-on.
+ */
+public class CopyAddOn extends Copy {
+
+    private static final String DEFAULT_DIR_PATH = "../zaproxy/src/plugin/";
+
+    private final Property<String> addOnId;
+
+    public CopyAddOn() {
+        Project project = getProject();
+        addOnId = project.getObjects().property(String.class);
+
+        from(project.getTasks().named("jarZapAddOn"));
+        into(new File(project.getRootDir(), DEFAULT_DIR_PATH));
+
+        getOutputs()
+                .upToDateWhen(
+                        task -> {
+                            Path dir = getDestinationDir().toPath();
+                            if (!Files.exists(dir)) {
+                                return true;
+                            }
+                            Pattern addOnIdPattern =
+                                    Pattern.compile(
+                                            Pattern.quote(getAddOnId().get())
+                                                    + "-.*\\."
+                                                    + Constants.ADD_ON_FILE_EXTENSION);
+                            try (Stream<Path> stream =
+                                    Files.find(
+                                            dir,
+                                            1,
+                                            (p, a) ->
+                                                    addOnIdPattern
+                                                            .matcher(p.getFileName().toString())
+                                                            .matches())) {
+                                return stream.count() <= 1;
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            }
+                        });
+    }
+
+    @Input
+    public Property<String> getAddOnId() {
+        return addOnId;
+    }
+
+    @Option(option = "into", description = "The file system path to the directory.")
+    public void optionInto(String dir) {
+        into(getProject().file(dir));
+    }
+
+    @Override
+    public void copy() {
+        Project project = getProject();
+        project.delete(
+                project.fileTree(
+                                getDestinationDir(),
+                                tree -> {
+                                    tree.include(
+                                            getAddOnId().get()
+                                                    + "-*."
+                                                    + Constants.ADD_ON_FILE_EXTENSION);
+                                })
+                        .getFiles());
+        super.copy();
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/misc/DeployAddOn.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/DeployAddOn.java
@@ -1,0 +1,160 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.misc;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.SystemUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+/**
+ * A task that deploys the add-on and corresponding home files into a ZAP home directory.
+ *
+ * <p>Defaults to dev home dir if not specified through the command line {@code --zap-home-dir} nor
+ * through the system property {@code zap.home.dir}. The command line argument takes precedence over
+ * the system property.
+ *
+ * <p>By default the existing home files are deleted before deploying the new files, to prevent
+ * stale files. This behaviour can be changed through the property {@link #getDeleteStale()
+ * deleteStale} or by setting the command line argument {@code --delete-stale} to false.
+ */
+public class DeployAddOn extends DefaultTask {
+
+    private static final String PLUGIN_DIR = "plugin";
+
+    private static String devHomeDir;
+
+    private final DirectoryProperty homeDir;
+    private final RegularFileProperty addOn;
+    private final ConfigurableFileCollection files;
+    private final Property<Boolean> deleteStale;
+
+    public DeployAddOn() {
+        ObjectFactory objects = getProject().getObjects();
+        homeDir = objects.directoryProperty();
+        homeDir.set(getDefaultHomeDir());
+        addOn = objects.fileProperty();
+        files = getProject().files();
+        deleteStale = objects.property(Boolean.class).value(true);
+    }
+
+    @Option(option = "zap-home-dir", description = "The file system path to the ZAP home.")
+    public void optionHomeDir(String dir) {
+        homeDir.set(getProject().file(dir));
+    }
+
+    @Input
+    public DirectoryProperty getHomeDir() {
+        return homeDir;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getAddOn() {
+        return addOn;
+    }
+
+    @Optional
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public ConfigurableFileCollection getFiles() {
+        return files;
+    }
+
+    @Input
+    public Property<Boolean> getDeleteStale() {
+        return deleteStale;
+    }
+
+    @Option(
+            option = "delete-stale",
+            description =
+                    "If stale add-on files in the home directory should be deleted, defaults to true.")
+    public void optionDeleteStale(String delete) {
+        deleteStale.set(Boolean.valueOf(delete));
+    }
+
+    @TaskAction
+    public void deploy() {
+        if (deleteStale.get()) {
+            List<File> filesToDelete = new ArrayList<>();
+            files.getAsFileTree()
+                    .visit(
+                            fileDetails -> {
+                                filesToDelete.add(
+                                        new File(
+                                                homeDir.get().getAsFile(),
+                                                fileDetails.getRelativePath().toString()));
+                            });
+            getProject().delete(filesToDelete);
+        }
+
+        getProject()
+                .copy(
+                        copySpec -> {
+                            copySpec.from(addOn, copySpecAddOn -> copySpecAddOn.into(PLUGIN_DIR));
+                            copySpec.from(files);
+                            copySpec.into(getHomeDir());
+                        });
+    }
+
+    private File getDefaultHomeDir() {
+        String destDir = null;
+        if (getProject().hasProperty("zap.home.dir")) {
+            destDir = (String) getProject().property("zap.home.dir");
+        }
+        if (destDir == null || destDir.isEmpty()) {
+            destDir = getDevHomeDir();
+        }
+        return getProject().file(destDir);
+    }
+
+    // Same logic used by ZAP.
+    private static String getDevHomeDir() {
+        if (devHomeDir == null) {
+            devHomeDir = System.getProperty("user.home");
+            if (devHomeDir == null) {
+                devHomeDir = ".";
+            }
+            if (SystemUtils.IS_OS_LINUX) {
+                devHomeDir += "/.ZAP_D";
+            } else if (SystemUtils.IS_OS_MAC) {
+                devHomeDir += "/Library/Application Support/ZAP_D";
+            } else {
+                devHomeDir += "\\OWASP ZAP_D";
+            }
+        }
+        return devHomeDir;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/misc/InstallAddOn.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/InstallAddOn.java
@@ -1,0 +1,75 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.misc;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ApiResponseElement;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+import org.zaproxy.gradle.addon.AddOnPluginException;
+
+/** A task that installs an add-on into ZAP. */
+public class InstallAddOn extends ZapApiTask {
+
+    private final RegularFileProperty addOn;
+
+    public InstallAddOn() {
+        addOn = getProject().getObjects().fileProperty();
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getAddOn() {
+        return addOn;
+    }
+
+    @TaskAction
+    public void start() {
+        ClientApi client = createClient();
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("file", getAddOn().get().getAsFile().toString());
+        try {
+            if (!isResponseOk(
+                    client.callApi("autoupdate", "action", "installLocalAddon", parameters))) {
+                throw new AddOnPluginException(
+                        "Failed to install the add-on, check ZAP log for more details.");
+            }
+        } catch (ClientApiException e) {
+            throw new AddOnPluginException(
+                    "An error occurred while installing the add-on: " + e.getMessage(), e);
+        }
+    }
+
+    private static boolean isResponseOk(ApiResponse response) {
+        if (response instanceof ApiResponseElement) {
+            return ApiResponseElement.OK
+                    .getValue()
+                    .equals(((ApiResponseElement) response).getValue());
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/misc/UninstallAddOn.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/UninstallAddOn.java
@@ -1,0 +1,68 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.misc;
+
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ApiResponseList;
+import org.zaproxy.clientapi.core.ApiResponseSet;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+import org.zaproxy.gradle.addon.AddOnPluginException;
+
+/** A task that uninstalls an add-on from ZAP. */
+public class UninstallAddOn extends ZapApiTask {
+
+    private final Property<String> addOnId;
+
+    public UninstallAddOn() {
+        addOnId = getProject().getObjects().property(String.class);
+    }
+
+    @Input
+    public Property<String> getAddOnId() {
+        return addOnId;
+    }
+
+    @TaskAction
+    public void start() {
+        ClientApi client = createClient();
+        try {
+            String id = getAddOnId().get();
+            if (hasAddOn(client.callApi("autoupdate", "view", "localAddons", null), id)) {
+                client.autoupdate.uninstallAddon(id);
+            }
+        } catch (ClientApiException e) {
+            throw new AddOnPluginException(
+                    "Failed to uninstall the old version of the add-on: " + e.getMessage(), e);
+        }
+    }
+
+    private static boolean hasAddOn(ApiResponse addOns, String addOnId) {
+        for (ApiResponse addOnData : ((ApiResponseList) addOns).getItems()) {
+            if (addOnId.equals(((ApiResponseSet) addOnData).getStringValue("id"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/misc/ZapApiTask.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/ZapApiTask.java
@@ -1,0 +1,90 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.misc;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.options.Option;
+import org.zaproxy.clientapi.core.ClientApi;
+
+/** A task that accesses the ZAP API. */
+public class ZapApiTask extends DefaultTask {
+
+    private static final String DEFAULT_ADDRESS = "127.0.0.1";
+    private static final int DEFAULT_PORT = 8080;
+
+    private final Property<String> address;
+    private final Property<Integer> port;
+    private final Property<String> apiKey;
+
+    public ZapApiTask() {
+        ObjectFactory objects = getProject().getObjects();
+        address = objects.property(String.class).value(DEFAULT_ADDRESS);
+        port = objects.property(Integer.class).value(DEFAULT_PORT);
+        apiKey = objects.property(String.class);
+    }
+
+    @Input
+    public Property<String> getAddress() {
+        return address;
+    }
+
+    @Input
+    public Property<Integer> getPort() {
+        return port;
+    }
+
+    @Option(option = "port", description = "The port where ZAP is or will be listening.")
+    public void optionPort(String port) {
+        try {
+            getPort().set(Integer.parseInt(port));
+        } catch (NumberFormatException e) {
+            throwInvalidPort(port);
+        }
+    }
+
+    @Input
+    @Optional
+    public Property<String> getApiKey() {
+        return apiKey;
+    }
+
+    protected ClientApi createClient() {
+        validatePort(port.get());
+
+        return new ClientApi(address.get(), port.get(), apiKey.getOrNull());
+    }
+
+    private static void validatePort(int port) {
+        if (port <= 0 || port > 65535) {
+            throwInvalidPort(port);
+        }
+    }
+
+    private static void throwInvalidPort(Object port) {
+        throw new IllegalArgumentException(
+                String.format(
+                        "The specified port '%1s' is not valid, it should be > 0 and <= 65535.",
+                        port));
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/wiki/WikiGenExtension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/wiki/WikiGenExtension.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.wiki;
+
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+
+public class WikiGenExtension {
+
+    private final Property<String> wikiFilesPrefix;
+    private final DirectoryProperty wikiDir;
+
+    @Inject
+    public WikiGenExtension(Project project) {
+        ObjectFactory objects = project.getObjects();
+        wikiFilesPrefix = objects.property(String.class);
+        wikiDir = objects.directoryProperty();
+    }
+
+    public Property<String> getWikiFilesPrefix() {
+        return wikiFilesPrefix;
+    }
+
+    public DirectoryProperty getWikiDir() {
+        return wikiDir;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/wiki/internal/SourceFile.java
+++ b/src/main/java/org/zaproxy/gradle/addon/wiki/internal/SourceFile.java
@@ -1,0 +1,41 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.wiki.internal;
+
+import java.net.URL;
+
+public class SourceFile {
+
+    private final URL path;
+    private final String relativePath;
+
+    public SourceFile(URL path, String relativePath) {
+        this.path = path;
+        this.relativePath = relativePath;
+    }
+
+    public URL getPath() {
+        return path;
+    }
+
+    public String getRelativePath() {
+        return relativePath;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiGenerationException.java
+++ b/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiGenerationException.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.wiki.internal;
+
+public class WikiGenerationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public WikiGenerationException() {
+        super();
+    }
+
+    public WikiGenerationException(String message) {
+        super(message);
+    }
+
+    public WikiGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public WikiGenerationException(Throwable cause) {
+        super(cause);
+    }
+
+    protected WikiGenerationException(
+            String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiGenerator.java
+++ b/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiGenerator.java
@@ -1,0 +1,286 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.wiki.internal;
+
+import com.overzealous.remark.Options;
+import com.overzealous.remark.Remark;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.apache.commons.lang3.StringUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+public class WikiGenerator {
+
+    private static final Remark MARKDOWN_CONVERTER;
+
+    static {
+        Options options = Options.github();
+        options.tables = Options.Tables.LEAVE_AS_HTML;
+        options.preserveRelativeLinks = true;
+        MARKDOWN_CONVERTER = new Remark(options);
+    }
+
+    private static final String ABSOLUTE_SCHEME = "//";
+    private static final String HTTP_SCHEME = "http://";
+    private static final String HTTPS_SCHEME = "https://";
+    private static final String MAILTO_SCHEME = "mailto:";
+
+    private static final String MARKDOWN_EXTENSION = ".md";
+
+    private final Set<SourceFile> srcFiles;
+    private final String contentsDir;
+    private final String filenamePrefix;
+    private final Set<SourceImage> images;
+
+    public WikiGenerator(Set<SourceFile> srcFiles, String contentsDir, String filenamePrefix) {
+        this.srcFiles = srcFiles;
+        this.contentsDir = contentsDir;
+        this.filenamePrefix = filenamePrefix;
+        this.images = new HashSet<>();
+    }
+
+    public WikiGenerationResults generateWikiPages(Path destDir) {
+        SortedMap<String, URL> generatedFiles = new TreeMap<>();
+        SortedSet<String> wikiLinks = new TreeSet<>();
+        SortedSet<Path> generatedWikiFiles = new TreeSet<>();
+
+        LinkConversionHandler linksHandler = new LinkConversionHandler(wikiLinks);
+        for (SourceFile srcFile : srcFiles) {
+            String wikiFileName =
+                    WikiGeneratorUtils.createWikiFileName(
+                            filenamePrefix, srcFile.getRelativePath(), "");
+            URL path = generatedFiles.get(wikiFileName);
+            if (path != null) {
+                throw new WikiGenerationException(
+                        "Duplicated output file name ["
+                                + wikiFileName
+                                + "] for ["
+                                + path
+                                + "] and ["
+                                + srcFile.getPath()
+                                + "]");
+            }
+            generatedFiles.put(wikiFileName, srcFile.getPath());
+
+            Path destFile = destDir.resolve(wikiFileName + MARKDOWN_EXTENSION);
+
+            linksHandler.setCurrentFile(srcFile.getPath());
+            createWikiPage(srcFile, destFile, linksHandler);
+
+            generatedWikiFiles.add(destFile);
+        }
+
+        Path imagesDir = destDir.resolve("images");
+        for (SourceImage image : images) {
+            Path imageFile = imagesDir.resolve(image.getPath());
+            try {
+                Files.createDirectories(imageFile.getParent());
+            } catch (IOException e) {
+                throw new WikiGenerationException(
+                        "Failed to create the directory for image: " + imageFile, e);
+            }
+
+            try (InputStream inputStream = new BufferedInputStream(image.getUrl().openStream())) {
+                Files.copy(inputStream, imageFile);
+            } catch (IOException e) {
+                throw new WikiGenerationException(
+                        "Failed to copy image from ["
+                                + image.getPath()
+                                + "] to ["
+                                + imageFile
+                                + "]",
+                        e);
+            }
+        }
+
+        if (!generatedFiles.isEmpty()) {
+            wikiLinks.removeAll(generatedFiles.keySet());
+            if (!wikiLinks.isEmpty()) {
+                System.err.println(
+                        "The following wiki links that do not have corresponding wiki page: "
+                                + wikiLinks.toString());
+            }
+        }
+
+        return new WikiGenerationResults(generatedFiles.keySet(), generatedWikiFiles);
+    }
+
+    public static final class WikiGenerationResults {
+        private final SortedSet<String> wikiFileNames;
+        private final SortedSet<Path> generatedFiles;
+
+        private WikiGenerationResults(Set<String> wikiFileNames, SortedSet<Path> generatedFiles) {
+            this.wikiFileNames = Collections.unmodifiableSortedSet(new TreeSet<>(wikiFileNames));
+            this.generatedFiles = Collections.unmodifiableSortedSet(new TreeSet<>(generatedFiles));
+        }
+
+        public SortedSet<String> getWikiFileNames() {
+            return wikiFileNames;
+        }
+
+        public SortedSet<Path> getGeneratedFiles() {
+            return generatedFiles;
+        }
+    }
+
+    private static void createWikiPage(
+            SourceFile sourceFile, Path destWikiFile, LinkConversionHandler linkConversionHandler) {
+        try (Writer writer = Files.newBufferedWriter(destWikiFile, StandardCharsets.UTF_8);
+                InputStream is = sourceFile.getPath().openStream()) {
+            Document doc = Jsoup.parse(is, "UTF-8", "http://example.com");
+            convertLinks(doc, linkConversionHandler);
+
+            MARKDOWN_CONVERTER.withWriter(writer).convert(doc);
+        } catch (IOException e) {
+            throw new WikiGenerationException(
+                    "Failed to convert file: " + sourceFile.getRelativePath(), e);
+        }
+    }
+
+    private static void convertLinks(Document doc, LinkConversionHandler linksHandler) {
+        for (Element a : doc.getElementsByTag("a")) {
+            String href = a.attr("href");
+            if (href != null && !href.isEmpty()) {
+                a.attr("href", linksHandler.convertHyperLink(href));
+            }
+        }
+
+        for (Element a : doc.getElementsByTag("img")) {
+            String src = a.attr("src");
+            if (src != null && !src.isEmpty()) {
+                a.attr("src", linksHandler.convertImg(src));
+            }
+        }
+    }
+
+    private class LinkConversionHandler {
+
+        private final SortedSet<String> wikiLinks;
+        private URL currentFile;
+
+        public LinkConversionHandler(SortedSet<String> wikiLinks) {
+            this.wikiLinks = wikiLinks;
+        }
+
+        public void setCurrentFile(URL currentFile) {
+            this.currentFile = currentFile;
+        }
+
+        public String convertHyperLink(String href) {
+            if (isExternalLink(href)) {
+                return href;
+            }
+
+            String normalisedHref = href;
+            String anchor = null;
+            int idx = href.indexOf('#');
+            if (idx != -1) {
+                anchor = href.substring(idx);
+                normalisedHref = href.substring(0, idx);
+                if (normalisedHref.isEmpty()) {
+                    normalisedHref = currentFile.toString();
+                }
+            }
+
+            String path =
+                    WikiGeneratorUtils.normalisedPath(contentsDir, currentFile, normalisedHref);
+            String wikiLink = WikiGeneratorUtils.createWikiFileName(filenamePrefix, path, "");
+            wikiLinks.add(wikiLink);
+
+            if (anchor != null) {
+                wikiLink += anchor;
+            }
+
+            return wikiLink;
+        }
+
+        public String convertImg(String src) {
+            if (isExternalLink(src)) {
+                return src;
+            }
+
+            URL url = WikiGeneratorUtils.createUrlFor(currentFile, src);
+            String path = WikiGeneratorUtils.normalisedImagePath(contentsDir, url);
+            images.add(new SourceImage(url, path));
+
+            return "images/" + path;
+        }
+
+        private boolean isExternalLink(String href) {
+            return StringUtils.startsWithIgnoreCase(href, HTTP_SCHEME)
+                    || StringUtils.startsWithIgnoreCase(href, HTTPS_SCHEME)
+                    || StringUtils.startsWithIgnoreCase(href, ABSOLUTE_SCHEME)
+                    || StringUtils.startsWithIgnoreCase(href, MAILTO_SCHEME);
+        }
+    }
+
+    private static class SourceImage {
+        private final URL url;
+        private final String path;
+
+        public SourceImage(URL url, String path) {
+            this.url = url;
+            this.path = path;
+        }
+
+        public URL getUrl() {
+            return url;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(path);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            return path.equals(((SourceImage) obj).path);
+        }
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiGeneratorUtils.java
+++ b/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiGeneratorUtils.java
@@ -1,0 +1,93 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.wiki.internal;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+public final class WikiGeneratorUtils {
+
+    private static final Pattern HTML_EXTENSION =
+            Pattern.compile("\\.html$", Pattern.CASE_INSENSITIVE);
+
+    private WikiGeneratorUtils() {}
+
+    public static String createWikiFileName(String filenamePrefix, String path) {
+        return createWikiFileName(filenamePrefix, path, "");
+    }
+
+    public static String createWikiFileName(
+            String filenamePrefix, String path, String newFileExtension) {
+        StringBuilder strBuilderFileName = new StringBuilder();
+        strBuilderFileName.append(filenamePrefix);
+        String[] segments = path.split("/", -1);
+        for (int i = 0; i < segments.length - 1; i++) {
+            strBuilderFileName.append(StringUtils.capitalize(segments[i]));
+        }
+        String fileName = StringUtils.capitalize(segments[segments.length - 1]);
+        strBuilderFileName.append(HTML_EXTENSION.matcher(fileName).replaceFirst(newFileExtension));
+
+        return strBuilderFileName.toString();
+    }
+
+    public static URL createUrlFor(URL file, String path) {
+        try {
+            return new URL(file, path);
+        } catch (MalformedURLException e) {
+            throw new WikiGenerationException(
+                    "Failed to create the URL with " + file + " and " + path, e);
+        }
+    }
+
+    public static String normalisedPath(String baseDir, URL file, String path) {
+        return normalisedPath(baseDir, createUrlFor(file, path));
+    }
+
+    public static String normalisedPath(String baseDir, URL url) {
+        return normalisePath(baseDir, extractPath(url));
+    }
+
+    private static String normalisePath(String baseDir, String path) {
+        if (!path.startsWith(baseDir)) {
+            throw new WikiGenerationException("Path " + path + " not under base dir " + baseDir);
+        }
+        return path.substring(baseDir.length() + 1);
+    }
+
+    private static String extractPath(URL url) {
+        String fileString = url.toString();
+        return fileString.substring(fileString.indexOf("!/") + 2);
+    }
+
+    public static String normalisedImagePath(String baseDir, URL url) {
+        String path = extractPath(url);
+        if (path.startsWith(baseDir)) {
+            path = normalisePath(baseDir, path);
+            if (path.startsWith("images")) {
+                path = path.substring("images".length() + 1);
+            }
+        } else {
+            path = path.substring(path.lastIndexOf('/') + 1);
+        }
+        return path;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiTocGenerator.java
+++ b/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiTocGenerator.java
@@ -1,0 +1,389 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.wiki.internal;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+public class WikiTocGenerator {
+
+    private static final Pattern IMAGES_PATTERN = Pattern.compile("(?i).*\\.(png|jpg)$");
+
+    private final String contentsDir;
+    private final URL toc;
+    private final URL map;
+    private final String outputFilenamePrefix;
+    private final Map<String, MapTarget> targetsMap;
+    private final List<TocItem> tocItems;
+
+    public WikiTocGenerator(URL toc, URL map, String contentsDir, String outputFilenamePrefix) {
+        this.contentsDir = contentsDir;
+        this.toc = toc;
+        this.map = map;
+        this.outputFilenamePrefix = outputFilenamePrefix;
+        this.targetsMap = createTargetsMap();
+        this.tocItems = createTocItems();
+    }
+
+    private Map<String, MapTarget> createTargetsMap() {
+        Element rootMapElement = null;
+        NodeList childNodes = createDocument(map).getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node childNode = childNodes.item(i);
+            if (childNode.getNodeType() == Node.ELEMENT_NODE
+                    && "map".equals(childNode.getNodeName())) {
+                rootMapElement = (Element) childNode;
+                break;
+            }
+        }
+
+        if (rootMapElement == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, MapTarget> targetToFile = new HashMap<>();
+        childNodes = rootMapElement.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); ++i) {
+            Node childNode = childNodes.item(i);
+            if (childNode.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            if ("mapID".equals(childNode.getNodeName())) {
+                Element childTocItemElement = (Element) childNode;
+                Attr attrTarget = childTocItemElement.getAttributeNode("target");
+                if (attrTarget == null) {
+                    throw new WikiGenerationException(
+                            "MapID element with no attribute \"target\".");
+                }
+                String target = attrTarget.getValue();
+                if (target.isEmpty()) {
+                    throw new WikiGenerationException(
+                            "MapID element with empty attribute \"target\".");
+                }
+
+                Attr attrUrl = childTocItemElement.getAttributeNode("url");
+                if (attrUrl == null) {
+                    throw new WikiGenerationException("MapID element with no attribute \"url\".");
+                }
+                String url = attrUrl.getValue();
+                if (url.isEmpty()) {
+                    throw new WikiGenerationException(
+                            "MapID element with empty attribute \"url\".");
+                }
+
+                targetToFile.put(target, createMapTarget(url));
+            }
+        }
+
+        if (targetToFile.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return targetToFile;
+    }
+
+    public void writeTo(Path outputFile) {
+        if (tocItems.isEmpty()) {
+            return;
+        }
+
+        if (Files.exists(outputFile) && !Files.isWritable(outputFile)) {
+            throw new WikiGenerationException(
+                    "The output file [" + outputFile + "] is not writable.");
+        }
+
+        try (Writer writer = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8)) {
+            writeTocItems(writer, tocItems, "");
+        } catch (IOException e) {
+            throw new WikiGenerationException("Failed to write the TOC.", e);
+        }
+    }
+
+    public void createImages(Path dir) {
+        Path imagesDir = dir.resolve("images");
+        try {
+            Files.createDirectories(imagesDir);
+        } catch (IOException e) {
+            throw new WikiGenerationException(
+                    "Failed to create the directory for images: " + imagesDir, e);
+        }
+
+        for (MapTarget targeMap : targetsMap.values()) {
+            targeMap.createImage(imagesDir);
+        }
+    }
+
+    private static void writeTocItems(Writer writer, List<TocItem> tocItems, String padding)
+            throws IOException {
+        for (TocItem tocItem : tocItems) {
+            writer.write(padding);
+            writer.write("* ");
+
+            if (tocItem.getImage() != null) {
+                writer.write("![](");
+                writer.write(tocItem.getImage());
+                writer.write(") ");
+            }
+
+            String target = tocItem.getTarget();
+            if (target != null) {
+                writer.write('[');
+            }
+
+            writer.write(tocItem.getText());
+
+            if (target != null) {
+                writer.write("](");
+                writer.write(target);
+                writer.write(')');
+            }
+
+            writer.append('\n');
+
+            writeTocItems(writer, tocItem.getChildren(), padding + "  ");
+        }
+    }
+
+    private List<TocItem> createTocItems() {
+        Element rootTocElement = null;
+        NodeList childNodes = createDocument(toc).getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node childNode = childNodes.item(i);
+            if (childNode.getNodeType() == Node.ELEMENT_NODE
+                    && "toc".equals(childNode.getNodeName())) {
+                rootTocElement = (Element) childNode;
+                break;
+            }
+        }
+
+        if (rootTocElement == null) {
+            return Collections.emptyList();
+        }
+
+        return createTocItemNodes(rootTocElement);
+    }
+
+    private List<TocItem> createTocItemNodes(Element tocItemElement) {
+        ArrayList<TocItem> items = new ArrayList<>(tocItemElement.getChildNodes().getLength());
+
+        NodeList childNodes = tocItemElement.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); ++i) {
+            Node childNode = childNodes.item(i);
+            if (childNode.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            if ("tocitem".equals(childNode.getNodeName())) {
+                Element childTocItemElement = (Element) childNode;
+                Attr attrText = childTocItemElement.getAttributeNode("text");
+                if (attrText == null) {
+                    throw new WikiGenerationException("TOC item with no attribute \"text\".");
+                }
+                String text = attrText.getValue();
+                if (text.isEmpty()) {
+                    throw new WikiGenerationException("TOC item with empty attribute \"text\".");
+                }
+
+                String target = getNonEmptyAttribute(childTocItemElement, "target");
+                if (target != null) {
+                    MapTarget mapTarget = targetsMap.get(target);
+                    if (mapTarget != null) {
+                        if (mapTarget.isImage()) {
+                            System.err.println(
+                                    "TOC attribute \"target\" points to an image [text="
+                                            + text
+                                            + ", target="
+                                            + target
+                                            + "].");
+                        }
+                        target = mapTarget.getWikiLink();
+                    } else {
+                        System.err.println(
+                                "No mapping for TOC entry with target attribute: " + target);
+                    }
+                }
+                String image = getNonEmptyAttribute(childTocItemElement, "image");
+                if (image != null) {
+                    MapTarget mapTarget = targetsMap.get(image);
+                    if (mapTarget == null) {
+                        throw new WikiGenerationException(
+                                "No mapping for TOC entry with image attribute: " + image);
+                    }
+                    if (!mapTarget.isImage()) {
+                        throw new WikiGenerationException(
+                                "TOC attribute \"image\" points to non image file [text="
+                                        + text
+                                        + ", image="
+                                        + image
+                                        + "].");
+                    }
+                    image = mapTarget.getWikiLink();
+                }
+
+                items.add(
+                        new TocItem(text, target, image, createTocItemNodes(childTocItemElement)));
+            }
+        }
+
+        items.trimToSize();
+        return items;
+    }
+
+    private static String getNonEmptyAttribute(Element element, String attribute) {
+        Attr attrLink = element.getAttributeNode(attribute);
+        if (attrLink != null) {
+            String linkValue = attrLink.getValue();
+            if (!linkValue.isEmpty()) {
+                return linkValue;
+            }
+        }
+        return null;
+    }
+
+    private MapTarget createMapTarget(String url) {
+        URL file = WikiGeneratorUtils.createUrlFor(map, url);
+
+        if (IMAGES_PATTERN.matcher(url).matches()) {
+            String path = WikiGeneratorUtils.normalisedImagePath(contentsDir, file);
+            String fileName = path.substring(path.lastIndexOf('/') + 1);
+            return new MapTarget("images/" + fileName, file, path);
+        }
+
+        return new MapTarget(
+                WikiGeneratorUtils.createWikiFileName(
+                        outputFilenamePrefix,
+                        WikiGeneratorUtils.normalisedPath(contentsDir, file),
+                        ""));
+    }
+
+    public static final class TocItem {
+
+        private final String text;
+        private final String target;
+        private final String image;
+        private final List<TocItem> children;
+
+        public TocItem(String text, String target, String image, List<TocItem> children) {
+            this.text = text;
+            this.target = target;
+            this.image = image;
+
+            if (children != null) {
+                this.children = Collections.unmodifiableList(new ArrayList<>(children));
+            } else {
+                this.children = Collections.emptyList();
+            }
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public String getTarget() {
+            return target;
+        }
+
+        public String getImage() {
+            return image;
+        }
+
+        public List<TocItem> getChildren() {
+            return children;
+        }
+    }
+
+    private static class MapTarget {
+
+        private final String wikiLink;
+        private final boolean image;
+
+        private final URL srcImageFile;
+        private final String imagePath;
+
+        public MapTarget(String wikiLink) {
+            this(wikiLink, null, null);
+        }
+
+        private MapTarget(String wikiLink, URL srcImageFile, String imagePath) {
+            this.wikiLink = wikiLink;
+            this.image = srcImageFile != null;
+            this.srcImageFile = srcImageFile;
+            this.imagePath = imagePath;
+        }
+
+        public String getWikiLink() {
+            return wikiLink;
+        }
+
+        public boolean isImage() {
+            return image;
+        }
+
+        public void createImage(Path dir) {
+            if (!image) {
+                return;
+            }
+            Path target = dir.resolve(imagePath);
+            try (InputStream inputStream = new BufferedInputStream(srcImageFile.openStream())) {
+                Files.copy(inputStream, target);
+            } catch (IOException e) {
+                throw new WikiGenerationException(
+                        "Failed to copy image from [" + srcImageFile + "] to [" + target + "]", e);
+            }
+        }
+    }
+
+    private static Document createDocument(URL url) {
+        try (InputStream inputStream = new BufferedInputStream(url.openStream())) {
+            DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+            builderFactory.setValidating(false);
+            builderFactory.setFeature(
+                    "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            builderFactory.setFeature(
+                    "http://xml.org/sax/features/external-general-entities", false);
+            builderFactory.setFeature(
+                    "http://xml.org/sax/features/external-parameter-entities", false);
+            DocumentBuilder builder = builderFactory.newDocumentBuilder();
+            return builder.parse(inputStream);
+        } catch (SAXException | ParserConfigurationException | IOException e) {
+            throw new WikiGenerationException("Failed to read file: " + url, e);
+        }
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/wiki/tasks/GenerateWiki.java
+++ b/src/main/java/org/zaproxy/gradle/addon/wiki/tasks/GenerateWiki.java
@@ -1,0 +1,155 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.wiki.tasks;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.Resource;
+import io.github.classgraph.ResourceList;
+import io.github.classgraph.ScanResult;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.gradle.addon.wiki.internal.SourceFile;
+import org.zaproxy.gradle.addon.wiki.internal.WikiGenerationException;
+import org.zaproxy.gradle.addon.wiki.internal.WikiGenerator;
+import org.zaproxy.gradle.addon.wiki.internal.WikiTocGenerator;
+
+/** A task to generate the wiki files from the help of the add-on. */
+public class GenerateWiki extends DefaultTask {
+
+    private final RegularFileProperty javaHelpData;
+
+    private final Property<String> contentsDir;
+
+    private final Property<String> wikiFilesPrefix;
+
+    private final Property<String> toc;
+    private final Property<String> map;
+    private final RegularFileProperty wikiToc;
+    private final DirectoryProperty outputDir;
+
+    public GenerateWiki() {
+        ObjectFactory objects = getProject().getObjects();
+        javaHelpData = objects.fileProperty();
+        contentsDir = objects.property(String.class);
+        wikiFilesPrefix = objects.property(String.class);
+        toc = objects.property(String.class);
+        map = objects.property(String.class);
+        wikiToc = objects.fileProperty();
+        outputDir = objects.directoryProperty();
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getJavaHelpData() {
+        return javaHelpData;
+    }
+
+    @Input
+    public Property<String> getContentsDir() {
+        return contentsDir;
+    }
+
+    @Input
+    public Property<String> getWikiFilesPrefix() {
+        return wikiFilesPrefix;
+    }
+
+    @Input
+    public Property<String> getToc() {
+        return toc;
+    }
+
+    @Input
+    public Property<String> getMap() {
+        return map;
+    }
+
+    @OutputFile
+    public RegularFileProperty getWikiToc() {
+        return wikiToc;
+    }
+
+    @OutputDirectory
+    public DirectoryProperty getOutputDir() {
+        return outputDir;
+    }
+
+    @TaskAction
+    public void generate() {
+        getProject().delete(outputDir.get().getAsFile());
+        getProject().mkdir(outputDir.get().getAsFile());
+
+        Path destDir = outputDir.get().getAsFile().toPath();
+
+        URL tocUrl;
+        URL mapUrl;
+        Set<SourceFile> sourceFiles;
+        try (ScanResult scanResult =
+                new ClassGraph().overrideClasspath(javaHelpData.get().getAsFile()).scan()) {
+            tocUrl = getUrl(scanResult, toc.get());
+            mapUrl = getUrl(scanResult, map.get());
+            sourceFiles = createSourceFiles(contentsDir.get(), scanResult);
+        }
+
+        WikiGenerator wikiGenerator =
+                new WikiGenerator(sourceFiles, contentsDir.get(), wikiFilesPrefix.get());
+        wikiGenerator.generateWikiPages(destDir);
+
+        WikiTocGenerator wikiTocGenerator =
+                new WikiTocGenerator(tocUrl, mapUrl, contentsDir.get(), wikiFilesPrefix.get());
+        wikiTocGenerator.writeTo(wikiToc.get().getAsFile().toPath());
+        wikiTocGenerator.createImages(destDir);
+    }
+
+    private static URL getUrl(ScanResult scanResult, String path) {
+        ResourceList resources = scanResult.getResourcesWithPath(path);
+        if (resources.isEmpty()) {
+            throw new WikiGenerationException("File not found in provided JAR: " + path);
+        }
+        return resources.get(0).getURL();
+    }
+
+    private static Set<SourceFile> createSourceFiles(String contentsDir, ScanResult scanResult) {
+        Set<SourceFile> sourceFiles = new HashSet<>();
+        for (Resource file :
+                scanResult.getResourcesMatchingPattern(
+                        Pattern.compile(Pattern.quote(contentsDir) + ".*\\.html"))) {
+            sourceFiles.add(
+                    new SourceFile(
+                            file.getURL(), file.getPath().substring(contentsDir.length() + 1)));
+        }
+        return sourceFiles;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/zapversions/ZapVersionsExtension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/zapversions/ZapVersionsExtension.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.zapversions;
+
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+
+public class ZapVersionsExtension {
+
+    private final RegularFileProperty addOn;
+    private final Property<String> downloadUrl;
+    private final Property<String> checksumAlgorithm;
+    private final RegularFileProperty file;
+
+    @Inject
+    public ZapVersionsExtension(Project project) {
+        ObjectFactory objects = project.getObjects();
+        this.addOn = objects.fileProperty();
+        this.downloadUrl = objects.property(String.class);
+        this.checksumAlgorithm = objects.property(String.class).value("SHA1");
+        this.file = objects.fileProperty();
+    }
+
+    public RegularFileProperty getAddOn() {
+        return addOn;
+    }
+
+    public Property<String> getDownloadUrl() {
+        return downloadUrl;
+    }
+
+    public Property<String> getChecksumAlgorithm() {
+        return checksumAlgorithm;
+    }
+
+    public RegularFileProperty getFile() {
+        return file;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/zapversions/tasks/AggregateZapVersionsFiles.java
+++ b/src/main/java/org/zaproxy/gradle/addon/zapversions/tasks/AggregateZapVersionsFiles.java
@@ -1,0 +1,89 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.zapversions.tasks;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import com.fasterxml.jackson.dataformat.xml.util.DefaultXmlPrettyPrinter;
+import java.io.IOException;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.UncheckedIOException;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.gradle.addon.internal.DefaultIndenter;
+import org.zaproxy.gradle.addon.internal.model.zapversions.ZapVersions;
+
+/** A task that merges {@code ZapVersions.xml} from add-ons into a single file. */
+public class AggregateZapVersionsFiles extends DefaultTask {
+
+    private final ConfigurableFileCollection from;
+    private final RegularFileProperty into;
+
+    public AggregateZapVersionsFiles() {
+        this.from = getProject().files();
+        this.into = getProject().getObjects().fileProperty();
+    }
+
+    @InputFiles
+    @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.NONE)
+    public ConfigurableFileCollection getFrom() {
+        return from;
+    }
+
+    @OutputFile
+    public RegularFileProperty getInto() {
+        return into;
+    }
+
+    @TaskAction
+    public void aggregate() throws IOException {
+        XmlMapper mapper = new XmlMapper();
+        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+
+        ZapVersions aggregatedZapVersions = new ZapVersions();
+
+        from.getFiles()
+                .forEach(
+                        f -> {
+                            ZapVersions zapVersions;
+                            try {
+                                zapVersions = mapper.readValue(f, ZapVersions.class);
+                                aggregatedZapVersions.addOns.add(zapVersions.addOns.first());
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            }
+                        });
+
+        DefaultXmlPrettyPrinter.Indenter indenter = new DefaultIndenter();
+        DefaultXmlPrettyPrinter printer = new DefaultXmlPrettyPrinter();
+        printer.indentObjectsWith(indenter);
+        printer.indentArraysWith(indenter);
+        mapper.writer(printer).writeValue(getInto().get().getAsFile(), aggregatedZapVersions);
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/zapversions/tasks/GenerateZapVersionsFile.java
+++ b/src/main/java/org/zaproxy/gradle/addon/zapversions/tasks/GenerateZapVersionsFile.java
@@ -1,0 +1,147 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.zapversions.tasks;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import com.fasterxml.jackson.dataformat.xml.util.DefaultXmlPrettyPrinter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.gradle.addon.internal.Constants;
+import org.zaproxy.gradle.addon.internal.DefaultIndenter;
+import org.zaproxy.gradle.addon.internal.model.Manifest;
+import org.zaproxy.gradle.addon.internal.model.zapversions.AddOn;
+import org.zaproxy.gradle.addon.internal.model.zapversions.ZapVersions;
+
+/** A task that generates a {@code ZapVersions.xml} file for a given add-on. */
+public class GenerateZapVersionsFile extends DefaultTask {
+
+    public static final String ZAP_VERSIONS_XML = "ZapVersions.xml";
+
+    private final Property<String> addOnId;
+    private final RegularFileProperty addOn;
+    private final Property<String> downloadUrl;
+    private final Property<String> checksumAlgorithm;
+    private final RegularFileProperty file;
+
+    public GenerateZapVersionsFile() {
+        ObjectFactory objects = getProject().getObjects();
+        this.addOnId = objects.property(String.class);
+        this.addOn = objects.fileProperty();
+        this.downloadUrl = objects.property(String.class);
+        this.checksumAlgorithm = objects.property(String.class).value("SHA1");
+        this.file = objects.fileProperty();
+    }
+
+    @Input
+    public Property<String> getAddOnId() {
+        return addOnId;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getAddOn() {
+        return addOn;
+    }
+
+    @Input
+    public Property<String> getDownloadUrl() {
+        return downloadUrl;
+    }
+
+    @Input
+    public Property<String> getChecksumAlgorithm() {
+        return checksumAlgorithm;
+    }
+
+    @OutputFile
+    public RegularFileProperty getFile() {
+        return file;
+    }
+
+    @TaskAction
+    public void generate() throws IOException {
+        File addOnFile = getAddOn().get().getAsFile();
+
+        Manifest manifest;
+        try (ZipFile addOnZip = new ZipFile(addOnFile)) {
+            ZipEntry manifestEntry = addOnZip.getEntry(Constants.ADD_ON_MANIFEST_FILE_NAME);
+            if (manifestEntry == null) {
+                throw new IllegalArgumentException(
+                        "The specified add-on does not have the manifest: " + addOnFile);
+            }
+            try (InputStream is = addOnZip.getInputStream(manifestEntry)) {
+                XmlMapper mapper = new XmlMapper();
+                mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+                manifest = mapper.readValue(is, Manifest.class);
+            }
+        }
+
+        AddOn addOnEntry = new AddOn();
+        addOnEntry.id = getAddOnId().get();
+        addOnEntry.name = manifest.name;
+        addOnEntry.description = manifest.description;
+        addOnEntry.author = manifest.author;
+        addOnEntry.version = manifest.version;
+        addOnEntry.semver = manifest.semver;
+        addOnEntry.file = addOnFile.getName();
+        addOnEntry.status = manifest.status;
+        addOnEntry.changes = manifest.changes;
+        addOnEntry.url = getDownloadUrl().get() + "/" + addOnFile.getName();
+        addOnEntry.hash = createChecksum(checksumAlgorithm.get(), addOnFile);
+        addOnEntry.info = manifest.url;
+        addOnEntry.date = LocalDate.now().toString();
+        addOnEntry.size = String.valueOf(addOnFile.length());
+        addOnEntry.notBeforeVersion = manifest.notBeforeVersion;
+        addOnEntry.notFromVersion = manifest.notFromVersion;
+        addOnEntry.dependencies = manifest.dependencies;
+
+        ZapVersions versions = new ZapVersions();
+        versions.addOns.add(addOnEntry);
+
+        DefaultXmlPrettyPrinter.Indenter indenter = new DefaultIndenter();
+        DefaultXmlPrettyPrinter printer = new DefaultXmlPrettyPrinter();
+        printer.indentObjectsWith(indenter);
+        printer.indentArraysWith(indenter);
+        XmlMapper mapper = new XmlMapper();
+        mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        mapper.writer(printer).writeValue(getFile().get().getAsFile(), versions);
+    }
+
+    private static String createChecksum(String algorithm, File addOnFile) throws IOException {
+        return algorithm + ":" + new DigestUtils(algorithm).digestAsHex(addOnFile);
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/zapversions/tasks/UpdateZapVersionsFile.java
+++ b/src/main/java/org/zaproxy/gradle/addon/zapversions/tasks/UpdateZapVersionsFile.java
@@ -1,0 +1,129 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.zapversions.tasks;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import com.fasterxml.jackson.dataformat.xml.util.DefaultXmlPrettyPrinter;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.workers.IsolationMode;
+import org.gradle.workers.WorkerExecutor;
+import org.zaproxy.gradle.addon.internal.DefaultIndenter;
+import org.zaproxy.gradle.addon.internal.model.zapversions.AddOn;
+import org.zaproxy.gradle.addon.internal.model.zapversions.ZapVersions;
+
+/**
+ * A task that updates {@code ZapVersions.xml} files with a {@code ZapVersions.xml} from an add-on.
+ */
+public class UpdateZapVersionsFile extends DefaultTask {
+
+    private final WorkerExecutor workerExecutor;
+    private final RegularFileProperty from;
+    private final ConfigurableFileCollection into;
+
+    @Inject
+    public UpdateZapVersionsFile(WorkerExecutor workerExecutor) {
+        this.workerExecutor = workerExecutor;
+        this.from = getProject().getObjects().fileProperty();
+        this.into = getProject().files();
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getFrom() {
+        return from;
+    }
+
+    @Internal
+    @SkipWhenEmpty
+    public ConfigurableFileCollection getInto() {
+        return into;
+    }
+
+    @TaskAction
+    public void update() throws IOException {
+        ZapVersions zapVersions =
+                createXmlMapper().readValue(from.get().getAsFile(), ZapVersions.class);
+        for (File file : into.getFiles()) {
+            if (Files.notExists(file.toPath())) {
+                throw new IOException("The file " + file.toPath() + " does not exist.");
+            }
+
+            AddOn addOn = zapVersions.addOns.first();
+            workerExecutor.submit(
+                    UpdateZapVersionsEntry.class,
+                    config -> {
+                        config.setIsolationMode(IsolationMode.NONE);
+                        config.params(addOn, file);
+                    });
+        }
+    }
+
+    protected static XmlMapper createXmlMapper() {
+        XmlMapper mapper = new XmlMapper();
+        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        return mapper;
+    }
+
+    public static class UpdateZapVersionsEntry implements Runnable {
+
+        private final AddOn addOn;
+        private final File file;
+
+        @Inject
+        public UpdateZapVersionsEntry(AddOn addOn, File file) {
+            this.addOn = addOn;
+            this.file = file;
+        }
+
+        @Override
+        public void run() {
+            try {
+                XmlMapper mapper = createXmlMapper();
+                ZapVersions zapVersions = mapper.readValue(file, ZapVersions.class);
+                zapVersions.addOns.remove(addOn);
+                zapVersions.addOns.add(addOn);
+
+                DefaultXmlPrettyPrinter.Indenter indenter = new DefaultIndenter();
+                DefaultXmlPrettyPrinter printer = new DefaultXmlPrettyPrinter();
+                printer.indentObjectsWith(indenter);
+                printer.indentArraysWith(indenter);
+                mapper.writer(printer).writeValue(file, zapVersions);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to update: " + file, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Update plugin with tasks to:
 - generate the manifest file for the add-on;
 - generate the ZAP API client files;
 - generate the `ZapVersion.xml` file;
 - assemble the add-on;
 - build the JavaHelp indexes;
 - generate the wiki files;
 - copy the wiki files to a directory;
 - copy the add-on (defaults to zaproxy project);
 - deploy the add-on and its home files to ZAP home dir;
 - install the add-on into ZAP;
 - uninstall the add-on from ZAP.

Update changelog with features added.
Add minimal README.
Update Gradle wrapper to latest version (5.2.1).