### PR TITLE
Fix wiki generation on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix wiki generation on Windows, which failed to find the help files.
 
 ### Removed
  - Remove features related to `ZapVersions.xml` file, the data will be generated in/by

--- a/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiGenerator.java
+++ b/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiGenerator.java
@@ -22,6 +22,7 @@ package org.zaproxy.gradle.addon.wiki.internal;
 import com.overzealous.remark.Options;
 import com.overzealous.remark.Remark;
 import java.io.BufferedInputStream;
+import java.io.FilterWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
@@ -158,7 +159,9 @@ public class WikiGenerator {
 
     private static void createWikiPage(
             SourceFile sourceFile, Path destWikiFile, LinkConversionHandler linkConversionHandler) {
-        try (Writer writer = Files.newBufferedWriter(destWikiFile, StandardCharsets.UTF_8);
+        try (Writer writer =
+                        new LineFeedWriter(
+                                Files.newBufferedWriter(destWikiFile, StandardCharsets.UTF_8));
                 InputStream is = sourceFile.getPath().openStream()) {
             Document doc = Jsoup.parse(is, "UTF-8", "http://example.com");
             convertLinks(doc, linkConversionHandler);
@@ -281,6 +284,18 @@ public class WikiGenerator {
                 return false;
             }
             return path.equals(((SourceImage) obj).path);
+        }
+    }
+
+    private static class LineFeedWriter extends FilterWriter {
+
+        protected LineFeedWriter(Writer out) {
+            super(out);
+        }
+
+        @Override
+        public void write(String str) throws IOException {
+            super.write(str.replace("\r", ""));
         }
     }
 }

--- a/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiGeneratorUtils.java
+++ b/src/main/java/org/zaproxy/gradle/addon/wiki/internal/WikiGeneratorUtils.java
@@ -67,7 +67,7 @@ public final class WikiGeneratorUtils {
     }
 
     private static String normalisePath(String baseDir, String path) {
-        if (!path.startsWith(baseDir)) {
+        if (!startsWithDir(path, baseDir)) {
             throw new WikiGenerationException("Path " + path + " not under base dir " + baseDir);
         }
         return path.substring(baseDir.length() + 1);
@@ -80,7 +80,7 @@ public final class WikiGeneratorUtils {
 
     public static String normalisedImagePath(String baseDir, URL url) {
         String path = extractPath(url);
-        if (path.startsWith(baseDir)) {
+        if (startsWithDir(path, baseDir)) {
             path = normalisePath(baseDir, path);
             if (path.startsWith("images")) {
                 path = path.substring("images".length() + 1);
@@ -89,5 +89,13 @@ public final class WikiGeneratorUtils {
             path = path.substring(path.lastIndexOf('/') + 1);
         }
         return path;
+    }
+
+    private static boolean startsWithDir(String path, String dir) {
+        return path.startsWith(normaliseFileSystemPath(dir));
+    }
+
+    public static String normaliseFileSystemPath(String path) {
+        return path.replace('\\', '/');
     }
 }

--- a/src/main/java/org/zaproxy/gradle/addon/wiki/tasks/GenerateWiki.java
+++ b/src/main/java/org/zaproxy/gradle/addon/wiki/tasks/GenerateWiki.java
@@ -43,6 +43,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.zaproxy.gradle.addon.wiki.internal.SourceFile;
 import org.zaproxy.gradle.addon.wiki.internal.WikiGenerationException;
 import org.zaproxy.gradle.addon.wiki.internal.WikiGenerator;
+import org.zaproxy.gradle.addon.wiki.internal.WikiGeneratorUtils;
 import org.zaproxy.gradle.addon.wiki.internal.WikiTocGenerator;
 
 /** A task to generate the wiki files from the help of the add-on. */
@@ -134,21 +135,24 @@ public class GenerateWiki extends DefaultTask {
     }
 
     private static URL getUrl(ScanResult scanResult, String path) {
-        ResourceList resources = scanResult.getResourcesWithPath(path);
+        String normalisedPath = WikiGeneratorUtils.normaliseFileSystemPath(path);
+        ResourceList resources = scanResult.getResourcesWithPath(normalisedPath);
         if (resources.isEmpty()) {
-            throw new WikiGenerationException("File not found in provided JAR: " + path);
+            throw new WikiGenerationException("File not found in provided JAR: " + normalisedPath);
         }
         return resources.get(0).getURL();
     }
 
     private static Set<SourceFile> createSourceFiles(String contentsDir, ScanResult scanResult) {
+        String normalisedContentsDir = WikiGeneratorUtils.normaliseFileSystemPath(contentsDir);
         Set<SourceFile> sourceFiles = new HashSet<>();
         for (Resource file :
                 scanResult.getResourcesMatchingPattern(
-                        Pattern.compile(Pattern.quote(contentsDir) + ".*\\.html"))) {
+                        Pattern.compile(Pattern.quote(normalisedContentsDir) + ".*\\.html"))) {
             sourceFiles.add(
                     new SourceFile(
-                            file.getURL(), file.getPath().substring(contentsDir.length() + 1)));
+                            file.getURL(),
+                            file.getPath().substring(normalisedContentsDir.length() + 1)));
         }
         return sourceFiles;
     }


### PR DESCRIPTION
Normalise the resource/file paths to always use the expected path
separator, otherwise it would not find them in the help JAR.
Ensure the generated files have consistent line endings (LF).