### PR TITLE
Remove redundant statement

### DIFF
--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
@@ -297,8 +297,6 @@ public class AddOnPlugin implements Plugin<Project> {
                                             .set(manifestExtension.getNotFromVersion());
                                     t.getClasspath().from(manifestExtension.getClasspath());
 
-                                    t.getClasspath().setFrom(manifestExtension.getClasspath());
-
                                     t.getOutputDir().set(manifestExtension.getOutputDir());
                                 });
         project.getTasks()


### PR DESCRIPTION
The manifest classpath is already being set up in the previous
statement.