### PR TITLE
Do not explicitly uninstall the add-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ - The `installZapAddOn` task will no longer depend on `uninstallZapAddOn` task, the uninstall will be
+ performed by ZAP to not require the uninstallation of dependent add-ons.
+ - The `jarZapAddOn` task no longer must run after `uninstallZapAddOn` task, ZAP now copies the add-on
+ to local plugin directory so the add-on built should no longer conflict with the one being uninstalled.
+
 ### Fixed
 - Fix wiki generation on Windows, which failed to find the help files.
 

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
@@ -630,17 +630,15 @@ public class AddOnPlugin implements Plugin<Project> {
                                                     .getFiles());
                         });
 
-        TaskProvider<UninstallAddOn> uninstallAddOn =
-                project.getTasks()
-                        .register(
-                                UNINSTALL_ADD_ON_TASK_NAME,
-                                UninstallAddOn.class,
-                                t -> {
-                                    t.setDescription(UNINSTALL_ADD_ON_TASK_DESC);
-                                    t.setGroup(ZAP_TASK_GROUP_NAME);
-                                    t.getAddOnId().set(extension.getAddOnId());
-                                });
-        jarZapAddOn.configure(t -> t.mustRunAfter(uninstallAddOn));
+        project.getTasks()
+                .register(
+                        UNINSTALL_ADD_ON_TASK_NAME,
+                        UninstallAddOn.class,
+                        t -> {
+                            t.setDescription(UNINSTALL_ADD_ON_TASK_DESC);
+                            t.setGroup(ZAP_TASK_GROUP_NAME);
+                            t.getAddOnId().set(extension.getAddOnId());
+                        });
 
         project.getTasks()
                 .register(
@@ -650,7 +648,6 @@ public class AddOnPlugin implements Plugin<Project> {
                             t.setDescription(INSTALL_ADD_ON_TASK_DESC);
                             t.setGroup(ZAP_TASK_GROUP_NAME);
 
-                            t.dependsOn(uninstallAddOn);
                             t.getAddOn().set(jarFile);
                         });
     }


### PR DESCRIPTION
Let ZAP uninstall the add-on when (re)installing it instead, to not
require uninstall dependent add-ons.
Remove ordering between `uninstallZapAddOn` and `jarZapAddOn`, ZAP now
copies the add-on to the local plugin directory so the add-on built
should no longer conflict with the one being uninstalled.