### PR TITLE
Add add-on release tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - Add (opinionated) tasks to help with the release of the add-on:
+   - `org.zaproxy.gradle.addon.misc.ConvertMarkdownToHtml` - converts markdown into HTML, for the add-on manifest.
+   - `org.zaproxy.gradle.addon.misc.CreateGitHubRelease` - creates a GitHub release.
+   - `org.zaproxy.gradle.addon.misc.ExtractLatestChangesFromChangelog` - extracts the changes from the
+   latest release, for example, to be included in the GitHub release or add-on manifest (after converting to HTML).
+   - `org.zaproxy.gradle.addon.misc.PrepareAddOnNextDevIter` - prepares the next development iteration
+   of the add-on. Updates the changelog (with Unreleased section) and bumps the version of the add-on.
+   - `org.zaproxy.gradle.addon.misc.PrepareAddOnRelease` - prepares the release of the add-on. Replaces the
+   Unreleased section of the changelog with the version, release date, and link to the release.
+
 ### Changed
  - The `installZapAddOn` task will no longer depend on `uninstallZapAddOn` task, the uninstall will be
  performed by ZAP to not require the uninstallation of dependent add-ons.
@@ -26,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      - `org.zaproxy.gradle.addon.zapversions.tasks.UpdateZapVersionsFile`
    - Extension:
      - `zapVersions` (in `zapAddOn`)
+ - Remove the task `org.zaproxy.gradle.addon.manifest.tasks.ConvertChangelogToChanges`,
+ split into two tasks (`ExtractLatestChangesFromChangelog` and `ConvertMarkdownToHtml`).
 
 ## [0.1.0] - 2019-03-11
 First alpha release.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,11 @@ dependencies {
     implementation("io.github.classgraph:classgraph:4.6.29")
     implementation("org.apache.commons:commons-lang3:3.8.1")
     implementation("org.zaproxy:zap-clientapi:1.6.0")
+    implementation("org.kohsuke:github-api:1.95")
+    // Include annotations used by the above library to avoid compiler warnings.
+    compileOnly("com.google.code.findbugs:findbugs-annotations:3.0.1")
+    compileOnly("com.infradna.tool:bridge-method-annotation:1.18")
+    implementation("com.github.zafarkhaja:java-semver:0.9.0")
 }
 
 tasks.jar {

--- a/src/main/java/org/zaproxy/gradle/addon/misc/ConvertMarkdownToHtml.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/ConvertMarkdownToHtml.java
@@ -1,0 +1,91 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.misc;
+
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughSubscriptExtension;
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.options.MutableDataSet;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+/** A task that converts markdown to HTML. */
+public class ConvertMarkdownToHtml extends DefaultTask {
+
+    private final RegularFileProperty markdown;
+    private final RegularFileProperty html;
+
+    public ConvertMarkdownToHtml() {
+        ObjectFactory objects = getProject().getObjects();
+        markdown = objects.fileProperty();
+        html = objects.fileProperty();
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getMarkdown() {
+        return markdown;
+    }
+
+    @OutputFile
+    public RegularFileProperty getHtml() {
+        return html;
+    }
+
+    @TaskAction
+    public void convert() throws IOException {
+        MutableDataSet options =
+                new MutableDataSet()
+                        .set(TablesExtension.COLUMN_SPANS, false)
+                        .set(TablesExtension.APPEND_MISSING_COLUMNS, true)
+                        .set(TablesExtension.DISCARD_EXTRA_COLUMNS, true)
+                        .set(TablesExtension.HEADER_SEPARATOR_COLUMN_MATCH, true)
+                        .set(
+                                Parser.EXTENSIONS,
+                                Arrays.asList(
+                                        StrikethroughSubscriptExtension.create(),
+                                        TablesExtension.create(),
+                                        TaskListExtension.create()));
+
+        Parser parser = Parser.builder(options).build();
+        HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+
+        String changes =
+                new String(
+                        Files.readAllBytes(markdown.get().getAsFile().toPath()),
+                        StandardCharsets.UTF_8);
+        try (Writer writer = Files.newBufferedWriter(html.get().getAsFile().toPath())) {
+            renderer.render(parser.parse(changes), writer);
+        }
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/misc/CreateGitHubRelease.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/CreateGitHubRelease.java
@@ -1,0 +1,204 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.misc;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Project;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.kohsuke.github.GHFileNotFoundException;
+import org.kohsuke.github.GHRelease;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+
+/** A task that creates a GitHub release. */
+public class CreateGitHubRelease extends DefaultTask {
+
+    private final Property<String> repo;
+    private final Property<String> authToken;
+    private final Property<String> tag;
+    private final Property<String> title;
+    private final Property<String> body;
+    private final RegularFileProperty bodyFile;
+    private NamedDomainObjectContainer<Asset> assets;
+
+    public CreateGitHubRelease() {
+        ObjectFactory objects = getProject().getObjects();
+        this.repo = objects.property(String.class);
+        this.authToken = objects.property(String.class);
+        this.tag = objects.property(String.class);
+        this.title = objects.property(String.class);
+        this.body = objects.property(String.class);
+        this.bodyFile = objects.fileProperty();
+        this.assets = getProject().container(Asset.class, label -> new Asset(label, getProject()));
+
+        setGroup("ZAP Add-On Misc");
+        setDescription("Creates a GitHub release.");
+    }
+
+    @Input
+    public Property<String> getRepo() {
+        return repo;
+    }
+
+    @Input
+    public Property<String> getAuthToken() {
+        return authToken;
+    }
+
+    @Input
+    public Property<String> getTag() {
+        return tag;
+    }
+
+    @Input
+    public Property<String> getTitle() {
+        return title;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getBody() {
+        return body;
+    }
+
+    @InputFile
+    @Optional
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getBodyFile() {
+        return bodyFile;
+    }
+
+    @Nested
+    @Optional
+    public Iterable<Asset> getAssets() {
+        return new ArrayList<>(assets);
+    }
+
+    public void setAssets(NamedDomainObjectContainer<Asset> assets) {
+        this.assets = assets;
+    }
+
+    public void assets(Action<? super NamedDomainObjectContainer<Asset>> action) {
+        action.execute(assets);
+    }
+
+    @TaskAction
+    public void createRelease() throws IOException {
+        if (getBodyFile().isPresent() && getBody().isPresent()) {
+            throw new InvalidUserDataException("Only one type of body property must be set.");
+        }
+
+        GHRepository ghRepo = GitHub.connect("", authToken.get()).getRepository(repo.get());
+
+        validateTagExists(ghRepo, tag.get());
+        validateReleaseDoesNotExist(ghRepo, tag.get());
+
+        String releaseBody =
+                getBodyFile().isPresent()
+                        ? readContents(getBodyFile().getAsFile().get().toPath())
+                        : body.get();
+
+        GHRelease release =
+                ghRepo.createRelease(tag.get())
+                        .name(title.get())
+                        .body(releaseBody)
+                        .draft(true)
+                        .create();
+
+        for (Asset asset : assets) {
+            release.uploadAsset(asset.getFile().getAsFile().get(), asset.getContentType().get());
+        }
+
+        release.update().draft(false).update();
+    }
+
+    private static void validateTagExists(GHRepository repo, String tag) throws IOException {
+        try {
+            repo.getRef("tags/" + tag);
+        } catch (GHFileNotFoundException e) {
+            throw new InvalidUserDataException("Tag does not exist: " + tag, e);
+        }
+    }
+
+    private static void validateReleaseDoesNotExist(GHRepository repo, String tag)
+            throws IOException {
+        GHRelease release = repo.getReleaseByTagName(tag);
+        if (release != null) {
+            throw new InvalidUserDataException(
+                    "Release for tag " + tag + " already exists: " + release.getHtmlUrl());
+        }
+    }
+
+    private static String readContents(Path file) throws IOException {
+        return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+    }
+
+    public static final class Asset implements Named {
+
+        private final String label;
+        private final RegularFileProperty file;
+        private final Property<String> contentType;
+
+        public Asset(String label, Project project) {
+            this.label = label;
+
+            ObjectFactory objectFactory = project.getObjects();
+            this.file = objectFactory.fileProperty();
+            this.contentType =
+                    objectFactory.property(String.class).value("application/octet-stream");
+        }
+
+        @Internal
+        @Override
+        public String getName() {
+            return label;
+        }
+
+        @InputFile
+        @PathSensitive(PathSensitivity.NONE)
+        public RegularFileProperty getFile() {
+            return file;
+        }
+
+        @Input
+        public Property<String> getContentType() {
+            return contentType;
+        }
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/misc/PrepareAddOnNextDevIter.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/PrepareAddOnNextDevIter.java
@@ -1,0 +1,184 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.misc;
+
+import com.github.zafarkhaja.semver.ParseException;
+import com.github.zafarkhaja.semver.Version;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.regex.Pattern;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * A task that prepares the next development iteration of an add-on.
+ *
+ * <p>Adds the Unreleased section to the changelog and bumps the version in the build file.
+ */
+public class PrepareAddOnNextDevIter extends DefaultTask {
+
+    private static final String UNRELEASED_SECTION = "## Unreleased";
+    private static final Pattern VERSION_PATTERN = Pattern.compile("## \\[?.+]?.*");
+
+    private final Property<String> currentVersion;
+    private final RegularFileProperty buildFile;
+    private final RegularFileProperty changelog;
+
+    public PrepareAddOnNextDevIter() {
+        ObjectFactory objects = getProject().getObjects();
+        this.currentVersion = objects.property(String.class);
+        this.buildFile = objects.fileProperty();
+        this.changelog = objects.fileProperty();
+
+        setGroup("ZAP Add-On Misc");
+        setDescription("Prepares the next development iteration of the add-on.");
+    }
+
+    @Input
+    public Property<String> getCurrentVersion() {
+        return currentVersion;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getBuildFile() {
+        return buildFile;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getChangelog() {
+        return changelog;
+    }
+
+    @TaskAction
+    public void prepare() throws IOException {
+        Path updatedChangelog = updateChangelog();
+        Path updatedBuildFile = updateBuildFile();
+
+        Files.copy(
+                updatedChangelog,
+                changelog.getAsFile().get().toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(
+                updatedBuildFile,
+                buildFile.getAsFile().get().toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private Path updateChangelog() throws IOException {
+        Path changelogPath = changelog.getAsFile().get().toPath();
+        Path updatedChangelog =
+                getTemporaryDir().toPath().resolve("updated-" + changelogPath.getFileName());
+
+        boolean insertUnreleased = true;
+
+        try (BufferedReader reader = Files.newBufferedReader(changelogPath);
+                BufferedWriter writer = Files.newBufferedWriter(updatedChangelog)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (insertUnreleased) {
+                    if (line.startsWith(UNRELEASED_SECTION)) {
+                        throw new InvalidUserDataException(
+                                "The changelog already contains the unreleased section.");
+                    }
+
+                    if (VERSION_PATTERN.matcher(line).find()) {
+                        writer.write(UNRELEASED_SECTION);
+                        writer.write("\n\n\n");
+                        insertUnreleased = false;
+                    }
+                }
+                writer.write(line);
+                writer.write("\n");
+            }
+        }
+
+        if (insertUnreleased) {
+            throw new InvalidUserDataException(
+                    "Failed to insert the unreleased section, no version section found.");
+        }
+
+        return updatedChangelog;
+    }
+
+    private Path updateBuildFile() throws IOException {
+        Path buildFilePath = buildFile.getAsFile().get().toPath();
+        Path updatedBuildFile =
+                getTemporaryDir().toPath().resolve("updated-" + buildFilePath.getFileName());
+
+        String currentVersionLine = versionLine(currentVersion.get());
+        String newVersion = bumpVersion(currentVersion.get());
+
+        boolean updateVersion = true;
+        try (BufferedReader reader = Files.newBufferedReader(buildFilePath);
+                BufferedWriter writer = Files.newBufferedWriter(updatedBuildFile)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (updateVersion && currentVersionLine.equals(line)) {
+                    line = versionLine(newVersion);
+                    updateVersion = false;
+                }
+                writer.write(line);
+                writer.write("\n");
+            }
+        }
+
+        if (updateVersion) {
+            throw new InvalidUserDataException(
+                    "Failed to update the version, current version line not found: "
+                            + currentVersionLine);
+        }
+
+        return updatedBuildFile;
+    }
+
+    private static String versionLine(String version) {
+        return "version = \"" + version + "\"";
+    }
+
+    private static String bumpVersion(String version) {
+        try {
+            int currentVersion = Integer.parseInt(version);
+            return Integer.toString(++currentVersion);
+        } catch (NumberFormatException e) {
+            // Ignore, not an integer version.
+        }
+
+        try {
+            return Version.valueOf(version).incrementMinorVersion().toString();
+        } catch (IllegalArgumentException | ParseException e) {
+            throw new InvalidUserDataException(
+                    "Failed to parse the current version: " + version, e);
+        }
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/misc/PrepareAddOnRelease.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/PrepareAddOnRelease.java
@@ -1,0 +1,132 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.misc;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDate;
+import java.util.regex.Pattern;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * A task that prepares the release of an add-on.
+ *
+ * <p>Replaces the Unreleased section and adds the release link to the changelog.
+ */
+public class PrepareAddOnRelease extends DefaultTask {
+
+    private static final Pattern VERSION_LINK_PATTERN = Pattern.compile("\\[.+]:");
+
+    private final Property<String> version;
+    private final Property<String> releaseLink;
+    private final Property<String> releaseDate;
+    private final RegularFileProperty changelog;
+
+    public PrepareAddOnRelease() {
+        ObjectFactory objects = getProject().getObjects();
+        this.version = objects.property(String.class);
+        this.releaseLink = objects.property(String.class);
+        this.releaseDate = objects.property(String.class).value(LocalDate.now().toString());
+        this.changelog = objects.fileProperty();
+
+        setGroup("ZAP Add-On Misc");
+        setDescription("Prepares the release of the add-on.");
+    }
+
+    @Input
+    public Property<String> getVersion() {
+        return version;
+    }
+
+    @Input
+    public Property<String> getReleaseLink() {
+        return releaseLink;
+    }
+
+    @Input
+    public Property<String> getReleaseDate() {
+        return releaseDate;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getChangelog() {
+        return changelog;
+    }
+
+    @TaskAction
+    public void prepare() throws IOException {
+        Path changelogPath = changelog.getAsFile().get().toPath();
+        Path updatedChangelog =
+                getTemporaryDir().toPath().resolve("updated-" + changelogPath.getFileName());
+
+        boolean replaceUnreleased = true;
+
+        try (BufferedReader reader = Files.newBufferedReader(changelogPath);
+                BufferedWriter writer = Files.newBufferedWriter(updatedChangelog)) {
+            boolean lastLineEmpty = false;
+            boolean insertLink = true;
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (insertLink && VERSION_LINK_PATTERN.matcher(line).find()) {
+                    writeReleaseLink(writer);
+                    insertLink = false;
+                } else if (replaceUnreleased && line.startsWith("## Unreleased")) {
+                    line = "## [" + version.get() + "] - " + releaseDate.get();
+                    replaceUnreleased = false;
+                }
+                writer.write(line);
+                writer.write("\n");
+                lastLineEmpty = line.isEmpty();
+            }
+
+            if (insertLink) {
+                if (!lastLineEmpty) {
+                    writer.write("\n");
+                }
+                writeReleaseLink(writer);
+            }
+        }
+
+        if (replaceUnreleased) {
+            throw new InvalidUserDataException("Changelog does not have the unreleased section.");
+        }
+
+        Files.copy(updatedChangelog, changelogPath, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private void writeReleaseLink(Writer writer) throws IOException {
+        writer.write("[" + version.get() + "]: " + releaseLink.get() + "\n");
+    }
+}


### PR DESCRIPTION
Add (opinionated) tasks to help with the release of the add-on:
 - `CreateGitHubRelease`, a task that creates a GitHub release.
 - `PrepareAddOnNextDevIter`, prepares the next development iteration of
 the add-on. Updates the changelog (with Unreleased section) and bumps
 the version of the add-on.
 - `PrepareAddOnRelease`, prepares the release of the add-on. Replaces
 the Unreleased section of the changelog with the version, release date,
 and link to the release.

Split `ConvertChangelogToChanges` into two tasks to support the above
use case:
 - `ExtractLatestChangesFromChangelog`, extracts the changes from the
 latest release, by keeping the changes in markdown they can be directly
 used in the GitHub release.
 - `ConvertMarkdownToHtml`, converts markdown into HTML to be included
 in the add-on manifest (as before).

---
The tasks `CreateGitHubRelease` and `PrepareAddOnNextDevIter` are exactly the same as the ones in the zap-extensions repo, the task `PrepareAddOnRelease` was tweaked to add a newline after the release link (so that `PrepareAddOnNextDevIter` does not introduce changes by adding the newline).