### PR TITLE
Add default and improve release related tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
- - Add (opinionated) tasks to help with the release of the add-on:
-   - `org.zaproxy.gradle.addon.misc.ConvertMarkdownToHtml` - converts markdown into HTML, for the add-on manifest.
-   - `org.zaproxy.gradle.addon.misc.CreateGitHubRelease` - creates a GitHub release.
-   - `org.zaproxy.gradle.addon.misc.ExtractLatestChangesFromChangelog` - extracts the changes from the
-   latest release, for example, to be included in the GitHub release or add-on manifest (after converting to HTML).
-   - `org.zaproxy.gradle.addon.misc.PrepareAddOnNextDevIter` - prepares the next development iteration
-   of the add-on. Updates the changelog (with Unreleased section) and bumps the version of the add-on.
-   - `org.zaproxy.gradle.addon.misc.PrepareAddOnRelease` - prepares the release of the add-on. Replaces the
-   Unreleased section of the changelog with the version, release date, and link to the release.
+Add (opinionated) tasks and extension properties to help with the release of the add-on.
+It makes use of a changelog, in Keep a Changelog format.
+
+#### Extension
+ - Add the following properties to `zapAddOn` extension:
+   - `changelog` to configure the location of the changelog (defaults to `CHANGELOG.md`).
+   - `releaseLink` to configure the release link added to the changelog when preparing the release.
+   - `unreleasedLink` to configure the unreleased link added to the changelog when preparing the next development
+   iteration.
+
+#### Tasks
+Added by the plugin:
+ - `extractLatestChanges` - to extract the latest changes from the changelog, kept in markdown.
+ - `generateManifestChanges` - to generate the manifest changes, by converting the latest changes to HTML. Needs to be
+ set to the `changesFile` of the `manifest`.
+ - `prepareAddOnRelease` - to prepare the release of the add-on.
+ - `prepareAddOnNextDevIter` - to prepare the next development iteration of the add-on.
+
+Provided by the plugin:
+ - `org.zaproxy.gradle.addon.misc.ConvertMarkdownToHtml` - converts markdown into HTML, for the add-on manifest.
+ - `org.zaproxy.gradle.addon.misc.CreateGitHubRelease` - creates a GitHub release.
+ - `org.zaproxy.gradle.addon.misc.ExtractLatestChangesFromChangelog` - extracts the changes from the
+ latest release, for example, to be included in the GitHub release or add-on manifest (after converting to HTML).
+ - `org.zaproxy.gradle.addon.misc.PrepareAddOnNextDevIter` - prepares the next development iteration
+ of the add-on. Updates the changelog (with Unreleased section) and bumps the version of the add-on.
+ - `org.zaproxy.gradle.addon.misc.PrepareAddOnRelease` - prepares the release of the add-on. Replaces the
+ Unreleased section of the changelog with the version, release date, and link to the release.
 
 ### Changed
  - The `installZapAddOn` task will no longer depend on `uninstallZapAddOn` task, the uninstall will be

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPluginExtension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPluginExtension.java
@@ -21,18 +21,23 @@ package org.zaproxy.gradle.addon;
 
 import javax.inject.Inject;
 import org.gradle.api.Project;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 
 /** The entry extension of the plugin. */
 public class AddOnPluginExtension {
 
     private static final String DEFAULT_ZAP_VERSION = "2.7.0";
+    private static final String DEFAULT_CHANGELOG_NAME = "CHANGELOG.md";
 
     private final Property<String> addOnId;
     private final Property<String> addOnName;
     private final Property<AddOnStatus> addOnStatus;
     private final Property<String> addOnVersion;
     private final Property<String> zapVersion;
+    private final RegularFileProperty changelog;
+    private final Property<String> releaseLink;
+    private final Property<String> unreleasedLink;
 
     @Inject
     public AddOnPluginExtension(Project project) {
@@ -44,6 +49,11 @@ public class AddOnPluginExtension {
         this.addOnVersion = project.getObjects().property(String.class);
         this.addOnVersion.set(project.provider(() -> project.getVersion().toString()));
         this.zapVersion = project.getObjects().property(String.class).value(DEFAULT_ZAP_VERSION);
+        this.changelog = project.getObjects().fileProperty();
+        this.changelog.value(
+                project.getLayout().getProjectDirectory().file(DEFAULT_CHANGELOG_NAME));
+        this.releaseLink = project.getObjects().property(String.class);
+        this.unreleasedLink = project.getObjects().property(String.class);
     }
 
     public Property<String> getAddOnId() {
@@ -64,5 +74,17 @@ public class AddOnPluginExtension {
 
     public Property<String> getZapVersion() {
         return zapVersion;
+    }
+
+    public RegularFileProperty getChangelog() {
+        return changelog;
+    }
+
+    public Property<String> getReleaseLink() {
+        return releaseLink;
+    }
+
+    public Property<String> getUnreleasedLink() {
+        return unreleasedLink;
     }
 }

--- a/src/main/java/org/zaproxy/gradle/addon/misc/PrepareAddOnNextDevIter.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/PrepareAddOnNextDevIter.java
@@ -24,6 +24,7 @@ import com.github.zafarkhaja.semver.Version;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -35,6 +36,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
@@ -42,20 +44,32 @@ import org.gradle.api.tasks.TaskAction;
 /**
  * A task that prepares the next development iteration of an add-on.
  *
- * <p>Adds the Unreleased section to the changelog and bumps the version in the build file.
+ * <p>Adds the Unreleased section and (optionally) the unreleased link to the changelog and bumps
+ * the version in the build file.
+ *
+ * <p>The unreleased link can have a token to refer to current version, which is replaced when
+ * adding the link.
  */
 public class PrepareAddOnNextDevIter extends DefaultTask {
 
+    public static final String CURRENT_VERSION_TOKEN = "@CURRENT_VERSION@";
+
     private static final String UNRELEASED_SECTION = "## Unreleased";
-    private static final Pattern VERSION_PATTERN = Pattern.compile("## \\[?.+]?.*");
+    private static final String UNRELEASED_SECTION_LINK = "## [Unreleased]";
+    private static final Pattern VERSION_SECTION_PATTERN = Pattern.compile("^## \\[?.+]?.*");
+    private static final Pattern VERSION_LINK_PATTERN = Pattern.compile("^\\[.+]:");
 
     private final Property<String> currentVersion;
+    private final Property<String> currentVersionToken;
+    private final Property<String> unreleasedLink;
     private final RegularFileProperty buildFile;
     private final RegularFileProperty changelog;
 
     public PrepareAddOnNextDevIter() {
         ObjectFactory objects = getProject().getObjects();
         this.currentVersion = objects.property(String.class);
+        this.currentVersionToken = objects.property(String.class).value(CURRENT_VERSION_TOKEN);
+        this.unreleasedLink = objects.property(String.class);
         this.buildFile = objects.fileProperty();
         this.changelog = objects.fileProperty();
 
@@ -66,6 +80,17 @@ public class PrepareAddOnNextDevIter extends DefaultTask {
     @Input
     public Property<String> getCurrentVersion() {
         return currentVersion;
+    }
+
+    @Input
+    public Property<String> getCurrentVersionToken() {
+        return currentVersionToken;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getUnreleasedLink() {
+        return unreleasedLink;
     }
 
     @InputFile
@@ -101,25 +126,44 @@ public class PrepareAddOnNextDevIter extends DefaultTask {
                 getTemporaryDir().toPath().resolve("updated-" + changelogPath.getFileName());
 
         boolean insertUnreleased = true;
+        boolean insertUnreleasedLink = unreleasedLink.isPresent();
 
         try (BufferedReader reader = Files.newBufferedReader(changelogPath);
                 BufferedWriter writer = Files.newBufferedWriter(updatedChangelog)) {
+            boolean lastLineEmpty = false;
             String line;
             while ((line = reader.readLine()) != null) {
                 if (insertUnreleased) {
-                    if (line.startsWith(UNRELEASED_SECTION)) {
+                    if (line.startsWith(UNRELEASED_SECTION)
+                            || line.startsWith(UNRELEASED_SECTION_LINK)) {
                         throw new InvalidUserDataException(
                                 "The changelog already contains the unreleased section.");
                     }
 
-                    if (VERSION_PATTERN.matcher(line).find()) {
-                        writer.write(UNRELEASED_SECTION);
+                    if (VERSION_SECTION_PATTERN.matcher(line).find()) {
+                        writer.write(
+                                insertUnreleasedLink
+                                        ? UNRELEASED_SECTION_LINK
+                                        : UNRELEASED_SECTION);
                         writer.write("\n\n\n");
                         insertUnreleased = false;
                     }
                 }
+                if (insertUnreleasedLink && VERSION_LINK_PATTERN.matcher(line).find()) {
+                    writeUnreleaseLink(writer);
+                    insertUnreleasedLink = false;
+                }
+
                 writer.write(line);
                 writer.write("\n");
+                lastLineEmpty = line.isEmpty();
+            }
+
+            if (insertUnreleasedLink) {
+                if (!lastLineEmpty) {
+                    writer.write("\n");
+                }
+                writeUnreleaseLink(writer);
             }
         }
 
@@ -180,5 +224,10 @@ public class PrepareAddOnNextDevIter extends DefaultTask {
             throw new InvalidUserDataException(
                     "Failed to parse the current version: " + version, e);
         }
+    }
+
+    private void writeUnreleaseLink(Writer writer) throws IOException {
+        String link = unreleasedLink.get().replace(currentVersionToken.get(), currentVersion.get());
+        writer.write("[Unreleased]: " + link + "\n");
     }
 }


### PR DESCRIPTION
Add release related tasks by default.
Allow to insert unreleased link when preparing the next development
iteration.
Add support for version tokens in the links, to make it easier to
compose them.
Allow to configure the location of the changelog and specify the release
links through the main extension.