### PR TITLE
Allow to specify add-on's repo location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - Allow to specify the location of the repo of the add-on. For example:
+   ```kts
+   manifest {
+     repo.set("https://github.com/zaproxy/zap-hud/tree/develop/")
+   }
+   ```
 
 ## [0.2.0] - 2019-05-20
 ### Added

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
@@ -316,6 +316,7 @@ public class AddOnPlugin implements Plugin<Project> {
                                     t.getUrl().set(manifestExtension.getUrl());
                                     t.getChanges().set(manifestExtension.getChanges());
                                     t.getChangesFile().set(manifestExtension.getChangesFile());
+                                    t.getRepo().set(manifestExtension.getRepo());
                                     t.getDependencies().set(manifestExtension.getDependencies());
                                     t.getBundle().set(manifestExtension.getBundle());
                                     t.getHelpSet().set(manifestExtension.getHelpSet());

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/Manifest.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/Manifest.java
@@ -62,6 +62,10 @@ public class Manifest implements Serializable {
     public String changes;
 
     @JsonProperty
+    @JsonInclude(value = Include.NON_EMPTY)
+    public String repo;
+
+    @JsonProperty
     @JsonInclude(value = Include.NON_NULL)
     public Classnames classnames;
 

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/ManifestExtension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/ManifestExtension.java
@@ -37,6 +37,7 @@ public class ManifestExtension {
     private final Property<String> url;
     private final Property<String> changes;
     private final RegularFileProperty changesFile;
+    private final Property<String> repo;
     private final Property<Dependencies> dependencies;
     private final Property<Bundle> bundle;
     private final Property<HelpSet> helpSet;
@@ -66,6 +67,7 @@ public class ManifestExtension {
         this.url = objects.property(String.class);
         this.changes = objects.property(String.class);
         this.changesFile = objects.fileProperty();
+        this.repo = objects.property(String.class);
         this.dependencies = objects.property(Dependencies.class);
         this.bundle = objects.property(Bundle.class);
         this.helpSet = objects.property(HelpSet.class);
@@ -103,6 +105,10 @@ public class ManifestExtension {
 
     public RegularFileProperty getChangesFile() {
         return changesFile;
+    }
+
+    public Property<String> getRepo() {
+        return repo;
     }
 
     public Property<Dependencies> getDependencies() {

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/tasks/GenerateManifestFile.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/tasks/GenerateManifestFile.java
@@ -81,6 +81,7 @@ public class GenerateManifestFile extends DefaultTask {
     private final Property<String> url;
     private final Property<String> changes;
     private final RegularFileProperty changesFile;
+    private final Property<String> repo;
     private final Property<Dependencies> dependencies;
     private final Property<Bundle> bundle;
     private final Property<HelpSet> helpSet;
@@ -110,6 +111,7 @@ public class GenerateManifestFile extends DefaultTask {
         this.url = objects.property(String.class);
         this.changes = objects.property(String.class);
         this.changesFile = objects.fileProperty();
+        this.repo = objects.property(String.class);
         this.dependencies = objects.property(Dependencies.class);
         this.bundle = objects.property(Bundle.class);
         this.helpSet = objects.property(HelpSet.class);
@@ -179,6 +181,12 @@ public class GenerateManifestFile extends DefaultTask {
     @Optional
     public RegularFileProperty getChangesFile() {
         return changesFile;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getRepo() {
+        return repo;
     }
 
     @Nested
@@ -355,6 +363,7 @@ public class GenerateManifestFile extends DefaultTask {
                 getChangesFile().isPresent()
                         ? readContents(getChangesFile().getAsFile().get().toPath())
                         : getChanges().getOrNull();
+        manifest.repo = getRepo().getOrNull();
 
         if (getDependencies().isPresent()) {
             Dependencies dep = getDependencies().get();


### PR DESCRIPTION
Change manifest extension/task to include the repo location.

Per changes in zaproxy/zaproxy#5572.