### PR TITLE
Allow to specify add-on's bundled dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      repo.set("https://github.com/zaproxy/zap-hud/tree/develop/")
    }
    ```
+ - Allow to bundle dependencies (instead of the add-on being an uber JAR), to properly maintain/access all
+ dependencies' JAR data (e.g. module info, manifest, services). For example, to bundle the runtime dependencies:
+   ```kts
+   manifest {
+     bundledLibs {
+       libs.from(configurations.runtimeClasspath)
+    }
+   }
+   ```
 
 ## [0.2.0] - 2019-05-20
 ### Added

--- a/src/main/java/org/zaproxy/gradle/addon/internal/model/Manifest.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/model/Manifest.java
@@ -73,6 +73,11 @@ public class Manifest implements Serializable {
     @JsonInclude(value = Include.NON_NULL)
     public Dependencies dependencies;
 
+    @JacksonXmlElementWrapper(localName = "libs")
+    @JacksonXmlProperty(localName = "lib")
+    @JsonInclude(value = Include.NON_EMPTY)
+    public List<String> libs = new ArrayList<>();
+
     @JsonProperty
     @JsonInclude(value = Include.NON_NULL)
     public Bundle bundle;

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/BundledLibs.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/BundledLibs.java
@@ -1,0 +1,54 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.addon.manifest;
+
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+
+public class BundledLibs {
+
+    private static final String DEFAULT_DIR_NAME = "libs";
+
+    private final Property<String> dirName;
+    private final ConfigurableFileCollection libs;
+
+    @Inject
+    public BundledLibs(Project project) {
+        this.dirName = project.getObjects().property(String.class).convention(DEFAULT_DIR_NAME);
+        this.libs = project.files();
+    }
+
+    @Input
+    public Property<String> getDirName() {
+        return dirName;
+    }
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.NAME_ONLY)
+    public ConfigurableFileCollection getLibs() {
+        return libs;
+    }
+}

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/ManifestExtension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/ManifestExtension.java
@@ -39,6 +39,7 @@ public class ManifestExtension {
     private final RegularFileProperty changesFile;
     private final Property<String> repo;
     private final Property<Dependencies> dependencies;
+    private final Property<BundledLibs> bundledLibs;
     private final Property<Bundle> bundle;
     private final Property<HelpSet> helpSet;
     private final Property<Classnames> classnames;
@@ -69,6 +70,7 @@ public class ManifestExtension {
         this.changesFile = objects.fileProperty();
         this.repo = objects.property(String.class);
         this.dependencies = objects.property(Dependencies.class);
+        this.bundledLibs = objects.property(BundledLibs.class);
         this.bundle = objects.property(Bundle.class);
         this.helpSet = objects.property(HelpSet.class);
         this.classnames = objects.property(Classnames.class);
@@ -120,6 +122,17 @@ public class ManifestExtension {
             dependencies.set(project.getObjects().newInstance(Dependencies.class, project));
         }
         action.execute(dependencies.get());
+    }
+
+    public Property<BundledLibs> getBundledLibs() {
+        return bundledLibs;
+    }
+
+    public void bundledLibs(Action<? super BundledLibs> action) {
+        if (!bundledLibs.isPresent()) {
+            bundledLibs.set(project.getObjects().newInstance(BundledLibs.class, project));
+        }
+        action.execute(bundledLibs.get());
     }
 
     public Property<Bundle> getBundle() {


### PR DESCRIPTION
Change manifest extension/task to allow to specify the bundled
dependencies and include them in the manifest.
Change `jarZapAddOn` task to bundle the dependencies.

Related to zaproxy/zaproxy#2619 - Allow add-ons to declare/bundle its
dependencies