### PR TITLE
copyZapAddOn: Update the help information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ - Update the copy destination in help information for the copyZapAddOn task.
 
 ## [0.3.0] - 2020-01-14
 ### Added

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
@@ -104,7 +104,7 @@ public class AddOnPlugin implements Plugin<Project> {
     public static final String COPY_ADD_ON_TASK_NAME = "copyZapAddOn";
 
     static final String COPY_ADD_ON_TASK_DESC =
-            "Copies the add-on to zaproxy project (defaults to \"$rootDir/../zaproxy/src/plugin/\").";
+            "Copies the add-on to zaproxy project (defaults to \"$rootDir/../zaproxy/zap/src/main/dist/plugin/\").";
 
     /**
      * The name of the task that deploys the add-on and its home files to ZAP home dir.


### PR DESCRIPTION
Change the copy location from $rootDir/../zaproxy/src/plugin/
to $rootDir/../zaproxy/zap/src/main/dist/plugin/.
@thc202: requesting review.