### PR TITLE
Correctly search for extensions and scan rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
  - Update the copy destination in help information for the copyZapAddOn task.
+ - Correctly search for extensions and scan rules when creating the add-on manifest. If an extension or scan rule
+ didn't extend directly from the core classes it would not have been included in the manifest.
 
 ## [0.3.0] - 2020-01-14
 ### Added

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
@@ -290,6 +290,11 @@ public class AddOnPlugin implements Plugin<Project> {
                                 .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
                                 .getOutput()
                                 .getClassesDirs());
+        ConfigurationContainer confs = project.getConfigurations();
+        manifestExtension
+                .getCompileClasspath()
+                .from(confs.named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+
         manifestExtension.getOutputDir().set(zapAddOnBuildDir);
 
         TaskProvider<GenerateManifestFile> generateTaskProvider =
@@ -327,6 +332,8 @@ public class AddOnPlugin implements Plugin<Project> {
                                     t.getNotFromVersion()
                                             .set(manifestExtension.getNotFromVersion());
                                     t.getClasspath().from(manifestExtension.getClasspath());
+                                    t.getCompileClasspath()
+                                            .from(manifestExtension.getCompileClasspath());
 
                                     t.getOutputDir().set(manifestExtension.getOutputDir());
                                 });

--- a/src/main/java/org/zaproxy/gradle/addon/manifest/ManifestExtension.java
+++ b/src/main/java/org/zaproxy/gradle/addon/manifest/ManifestExtension.java
@@ -51,6 +51,7 @@ public class ManifestExtension {
     private final Property<String> notFromVersion;
 
     private final ConfigurableFileCollection classpath;
+    private final ConfigurableFileCollection compileClasspath;
 
     private final DirectoryProperty outputDir;
 
@@ -82,6 +83,7 @@ public class ManifestExtension {
         this.notBeforeVersion = objects.property(String.class);
         this.notFromVersion = objects.property(String.class);
         this.classpath = project.files();
+        this.compileClasspath = project.files();
         this.outputDir = objects.directoryProperty();
     }
 
@@ -207,6 +209,10 @@ public class ManifestExtension {
 
     public ConfigurableFileCollection getClasspath() {
         return classpath;
+    }
+
+    public ConfigurableFileCollection getCompileClasspath() {
+        return compileClasspath;
     }
 
     public DirectoryProperty getOutputDir() {


### PR DESCRIPTION
Check the whole class hierarchy when searching for extensions and scan
rules for the add-on manifest, otherwise an extension or scan rule that
didn't extend directly from the core classes would not be included in
the manifest.