### PR TITLE
Add a task for each API generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add Go generator to task `GenerateApiClientFiles`.
+- Add tasks to generate API client files per language:
+  - `DotNet`, `generateDotNetZapApiClientFiles`;
+  - `Go`, `generateGoZapApiClientFiles`;
+  - `Java`, `generateJavaZapApiClientFiles`;
+  - `NodeJS`, `generateNodeJsZapApiClientFiles`;
+  - `PHP`, `generatePhpZapApiClientFiles`;
+  - `Python`, `generatePythonZapApiClientFiles`;
+  - `Rust`, `generateRustZapApiClientFiles`.
 - Allow to configure the default values used in API tasks (e.g. `installZapAddOn`) using the system properties:
   - `zap.api.address`, for the ZAP address;
   - `zap.api.port`, for the ZAP port;

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
@@ -199,7 +199,7 @@ public class AddOnPlugin implements Plugin<Project> {
     public static final String GENERATE_API_CLIENT_TASK_NAME = "generateZapApiClientFiles";
 
     static final String GENERATE_API_CLIENT_TASK_DESC =
-            "Generates the API client files for the ZAP add-on.";
+            "Generates (all) the API client files for the ZAP add-on.";
 
     private static final String ZAP_TASK_GROUP_NAME = "ZAP Add-On Misc";
 
@@ -705,15 +705,42 @@ public class AddOnPlugin implements Plugin<Project> {
                 .register(
                         GENERATE_API_CLIENT_TASK_NAME,
                         GenerateApiClientFiles.class,
-                        t -> {
-                            t.setDescription(GENERATE_API_CLIENT_TASK_DESC);
-                            t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+                        t ->
+                                setupGenerateApiClientFiles(
+                                        t,
+                                        GENERATE_API_CLIENT_TASK_DESC,
+                                        apiClientGenExtension,
+                                        GenerateApiClientFiles.ALL_LANGUAGES));
 
-                            t.getApi().set(apiClientGenExtension.getApi());
-                            t.getOptions().set(apiClientGenExtension.getOptions());
-                            t.getMessages().set(apiClientGenExtension.getMessages());
-                            t.getBaseDir().set(apiClientGenExtension.getBaseDir());
-                            t.getClasspath().setFrom(apiClientGenExtension.getClasspath());
-                        });
+        GenerateApiClientFiles.LANGUAGES.forEach(
+                lang ->
+                        project.getTasks()
+                                .register(
+                                        String.format("generate%sZapApiClientFiles", lang),
+                                        GenerateApiClientFiles.class,
+                                        t ->
+                                                setupGenerateApiClientFiles(
+                                                        t,
+                                                        String.format(
+                                                                "Generates the %s API client files for the ZAP add-on.",
+                                                                lang),
+                                                        apiClientGenExtension,
+                                                        lang)));
+    }
+
+    private static void setupGenerateApiClientFiles(
+            GenerateApiClientFiles task,
+            String description,
+            ApiClientGenExtension extension,
+            String language) {
+        task.setDescription(description);
+        task.setGroup(ZAP_TASK_GROUP_NAME);
+
+        task.getApi().set(extension.getApi());
+        task.getOptions().set(extension.getOptions());
+        task.getMessages().set(extension.getMessages());
+        task.getBaseDir().set(extension.getBaseDir());
+        task.getLanguage().set(language);
+        task.getClasspath().setFrom(extension.getClasspath());
     }
 }

--- a/src/main/java/org/zaproxy/gradle/addon/apigen/tasks/GenerateApiClientFiles.java
+++ b/src/main/java/org/zaproxy/gradle/addon/apigen/tasks/GenerateApiClientFiles.java
@@ -25,6 +25,9 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -43,10 +46,16 @@ import org.gradle.api.tasks.TaskAction;
 /** A task to generate the API client files of an add-on. */
 public class GenerateApiClientFiles extends DefaultTask {
 
+    public static final List<String> LANGUAGES =
+            Collections.unmodifiableList(
+                    Arrays.asList("DotNet", "Go", "Java", "NodeJs", "Php", "Python", "Rust"));
+    public static final String ALL_LANGUAGES = "ALL";
+
     private final Property<String> api;
     private final Property<String> options;
     private final RegularFileProperty messages;
     private final DirectoryProperty baseDir;
+    private final Property<String> language;
     private final ConfigurableFileCollection classpath;
 
     public GenerateApiClientFiles() {
@@ -56,6 +65,7 @@ public class GenerateApiClientFiles extends DefaultTask {
         messages = objects.fileProperty();
         baseDir = objects.directoryProperty();
         baseDir.set(getProject().getRootDir().getParentFile());
+        language = objects.property(String.class).value(ALL_LANGUAGES);
         classpath = getProject().files();
     }
 
@@ -81,6 +91,12 @@ public class GenerateApiClientFiles extends DefaultTask {
     @Optional
     public DirectoryProperty getBaseDir() {
         return baseDir;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getLanguage() {
+        return language;
     }
 
     @Classpath
@@ -118,6 +134,7 @@ public class GenerateApiClientFiles extends DefaultTask {
             conf.setProperty("api", api.get());
             conf.setProperty("options", options.isPresent() ? options.get() : "");
             conf.setProperty("basedir", baseDir.get().getAsFile().getAbsolutePath());
+            conf.setProperty("language", language.getOrElse(ALL_LANGUAGES));
             conf.store(out, null);
         }
 


### PR DESCRIPTION
Allow to generate the API client files of a specific language.
Change the group task of the main task and per language to be under ZAP
tasks, they are not part of the build.