### PR TITLE
chore: Upgrade Gradle to 7.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Recomended minimum Gradle version is now 7.2.
+- Recommended minimum Gradle version is now 7.3.3.
 
 ## [0.7.0] - 2021-07-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A Gradle plugin to (help) build ZAP add-ons.
 
-The plugin requires at least Java 8 and Gradle 7.2.
+The plugin requires at least Java 8 and Gradle 7.3.3.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=a8da5b02437a60819cad23e10fc7e9cf32bcb57029d9cb277e26eeff76ce014b
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionSha256Sum=c9490e938b221daf0094982288e4038deed954a3f12fb54cbf270ddf4e37d879
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright Â© 2015-2021 the original authors.
+# Copyright © 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
-#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
-#         * compound commands having a testable exit status, especially Â«caseÂ»;
-#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
+#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
+#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
+#         * compound commands having a testable exit status, especially «case»;
+#         * various built-in commands including «command», «set», and «ulimit».
 #
 #   Important for patching:
 #


### PR DESCRIPTION
Upgrade to use Gradle 7.3.3

https://services.gradle.org/distributions/gradle-7.3.3-all.zip.sha256

`./gradlew wrapper --gradle-version 7.3.3 --distribution-type all --gradle-distribution-sha256-sum=c9490e938b221daf0094982288e4038deed954a3f12fb54cbf270ddf4e37d879`

Checked with:
```console
./gradlew assemble --scan --warning-mode all
./gradlew build --no-build-cache --scan --warning-mode all
```

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>