### PR TITLE
Correct release tasks' ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Recommended minimum Gradle version is now 7.5.1.
 
+### Fixed
+- Ensure task `prepareNextDevIter` runs after both `createRelease` and `handleRelease`, not just the latter.
+
 ## [0.8.0] - 2022-01-17
 ### Changed
 - Recommended minimum Gradle version is now 7.3.3.

--- a/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/addon/AddOnPlugin.java
@@ -898,7 +898,10 @@ public class AddOnPlugin implements Plugin<Project> {
                         .register(
                                 PREPARE_NEXT_DEV_ITER_TASK_NAME,
                                 PrepareNextDevIter.class,
-                                t -> t.mustRunAfter(handleRelease));
+                                t -> {
+                                    t.mustRunAfter(createRelease);
+                                    t.mustRunAfter(handleRelease);
+                                });
 
         project.getTasks()
                 .register(


### PR DESCRIPTION
Ensure task `prepareNextDevIter` runs after both `createRelease` and `handleRelease`, not just the latter.