### PR TITLE
Add GitHub workflow to release the plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,12 @@ jobs:
         java: [11, 19]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ matrix.java }}-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-${{ matrix.java }}-
-            ${{ runner.os }}-gradle-
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/gradle-build-action@v2
       - run: ./gradlew assemble
       - run: ./gradlew check

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,0 +1,20 @@
+name: Release Plugin
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - uses: gradle/gradle-build-action@v2
+      - run: ./gradlew publishPlugin
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.ZAPBOT_GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.ZAPBOT_GRADLE_PUBLISH_SECRET }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `kotlin-dsl`
-    id("com.gradle.plugin-publish") version "1.0.0"
+    id("com.gradle.plugin-publish") version "1.1.0"
 
     id("com.diffplug.spotless") version "6.14.1"
 }
@@ -59,6 +59,8 @@ gradlePlugin {
             id = "org.zaproxy.add-on"
             implementationClass = "org.zaproxy.gradle.addon.AddOnPlugin"
             displayName = "Plugin to build ZAP add-ons"
+            description = "A Gradle plugin to (help) build ZAP add-ons."
+            tags.set(listOf("zap", "zaproxy"))
         }
     }
 }
@@ -66,8 +68,6 @@ gradlePlugin {
 pluginBundle {
     website = "https://github.com/zaproxy/gradle-plugin-add-on"
     vcsUrl = "https://github.com/zaproxy/gradle-plugin-add-on.git"
-    description = "A Gradle plugin to (help) build ZAP add-ons."
-    tags = listOf("zap", "zaproxy")
 }
 
 spotless {


### PR DESCRIPTION
Add workflow to publish the plugin to the Gradle Plugin Portal using zapbot's credentials.
Update Gradle Publish plugin to 1.1.0 and update its configuration.
Also, update CI workflow to use the same setup as other Gradle repos.