### PR TITLE
Use release task properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Correct the tasks `PrepareNextDevIter` and `PrepareRelease` to use their properties, for the `version` and `release`.
 
 ## [0.9.0] - 2023-03-15
 ### Changed

--- a/src/main/java/org/zaproxy/gradle/addon/internal/tasks/PrepareNextDevIter.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/tasks/PrepareNextDevIter.java
@@ -67,9 +67,10 @@ public abstract class PrepareNextDevIter extends UpdateChangelogNextDevIter {
 
         ProjectProperties properties =
                 new ProjectProperties(getPropertiesFile().get().getAsFile().toPath());
+        String versionProperty = getVersionProperty().get();
         properties.setProperty(
-                VERSION_PROPERTY, bumpVersion(properties.getProperty(VERSION_PROPERTY)));
-        properties.setProperty(RELEASE_PROPERTY, "false");
+                versionProperty, bumpVersion(properties.getProperty(versionProperty)));
+        properties.setProperty(getReleaseProperty().get(), "false");
         properties.store();
     }
 

--- a/src/main/java/org/zaproxy/gradle/addon/internal/tasks/PrepareRelease.java
+++ b/src/main/java/org/zaproxy/gradle/addon/internal/tasks/PrepareRelease.java
@@ -62,7 +62,7 @@ public abstract class PrepareRelease extends PrepareAddOnRelease {
 
         ProjectProperties properties =
                 new ProjectProperties(getPropertiesFile().get().getAsFile().toPath());
-        properties.setProperty(RELEASE_PROPERTY, "true");
+        properties.setProperty(getReleaseProperty().get(), "true");
         properties.store();
     }
 }


### PR DESCRIPTION
Use the `version` and `release` properties in the release tasks, instead of always the default values.