### PR TITLE
Update default ZAP home dir in Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Recommended minimum Gradle version is now 8.2.
 - Update ZAP API client to version 1.12.0.
+- The default ZAP home dir in Windows was changed to `ZAP_D`, to match the change done in ZAP itself.
 
 ### Fixed
 - Correct the tasks `PrepareNextDevIter` and `PrepareRelease` to use their properties, for the `version` and `release`.

--- a/src/main/java/org/zaproxy/gradle/addon/misc/DeployAddOn.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/DeployAddOn.java
@@ -151,7 +151,7 @@ public class DeployAddOn extends DefaultTask {
             } else if (SystemUtils.IS_OS_MAC) {
                 devHomeDir += "/Library/Application Support/ZAP_D";
             } else {
-                devHomeDir += "\\OWASP ZAP_D";
+                devHomeDir += "\\ZAP_D";
             }
         }
         return devHomeDir;


### PR DESCRIPTION
Use just `ZAP_D`.

Related to zaproxy/zaproxy#7988.