### PR TITLE
Normalize number of newlines on changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Normalize the number of newlines when updating the changelog.
 
 ## [0.10.0] - 2023-12-01
 ### Changed

--- a/src/main/java/org/zaproxy/gradle/addon/misc/UpdateChangelog.java
+++ b/src/main/java/org/zaproxy/gradle/addon/misc/UpdateChangelog.java
@@ -194,7 +194,7 @@ public class UpdateChangelog extends DefaultTask {
     }
 
     private String addChange(StringBuilder versionContents) {
-        String normalisedChange = change.get().replaceAll("\r\n?", "\n") + '\n';
+        String normalisedChange = change.get().replaceAll("\r?\n", "\n") + '\n';
         if (!isDuplicate()) {
             String contents = versionContents.toString();
             if (contents.contains(normalisedChange)) {
@@ -212,7 +212,7 @@ public class UpdateChangelog extends DefaultTask {
         }
         versionContents.insert(insertPosition, normalisedChange);
 
-        return versionContents.toString();
+        return versionContents.toString().trim() + "\n\n";
     }
 
     private boolean isDuplicate() {


### PR DESCRIPTION
Trim excessive newlines at the start and at the end of the unreleased content, leave just two for the separation with the following content.